### PR TITLE
ETOPO 1 arcmin is too large for hexagon

### DIFF
--- a/model/dataset.cpp
+++ b/model/dataset.cpp
@@ -4796,7 +4796,7 @@ DataSet::DataSet(char const *DatasetName)
         Dimension dimension_x={
             name:"lon", // for ETOPO_Arctic_1arcmin.nc
             //name:"x", // for ETOPO1_Ice_g_gmt4.grd
-            cyclic:false
+            cyclic:true
         };
 
         Dimension dimension_y={
@@ -4857,7 +4857,7 @@ DataSet::DataSet(char const *DatasetName)
             interp_type : BilinearInterpEnum,
             //interp_type : NearestInterpEnum,
             dirname:"data",
-            prefix:"ETOPO_Arctic_1arcmin.nc",
+            prefix:"ETOPO_Arctic_2arcmin.nc",
             //prefix:"ETOPO1_Ice_g_gmt4.grd",
             postfix:"",
             gridfile: "",


### PR DESCRIPTION
It seems to be enough to use the 2 arcmin to address issue #196. 2 arcmin should also be enough for everybody so I'm putting that in as default.