### PR TITLE
Fix for issue #214.

### DIFF
--- a/model/gridoutput.cpp
+++ b/model/gridoutput.cpp
@@ -178,6 +178,7 @@ GridOutput::initRegularGrid(BamgMesh* bamgmesh, int nb_local_el, int ncols, int 
 
     M_grid = Grid();
     M_grid.loaded = false;
+    M_grid.interp_method = interpMethod::meshToMesh;
 
     // Calculate lat and lon
     M_grid.gridLAT.assign(M_grid_size, 0.);


### PR DESCRIPTION
I forgot to set the interpMethod in case of a regular grid. It must always be meshToMesh (as of yet at least).

Can you test this in your setup Tim? I don't have valgrind running at the moment.