### PR TITLE
Hotfix240 cs2smos new

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -10277,7 +10277,7 @@ FiniteElement::cs2SmosIce()
     double oo_y = 0.99853900, oo_s = 0.09128844, oo_o = 0.65327181;
 
     // fraction of young ice
-    double fy0 = 0.20;
+    double fy0 = 0.10;
     // mean allowed thickness of young ice
     double ty0 = h_thin_min + 0.5 * (h_thin_max - h_thin_min);
     //double ty0 = 0.05;


### PR DESCRIPTION
This PR fixes #240:
* observation operator is applied to correct concentration using thickness from CS2SMOS
* young ice fraction is set to 20%
* young ice thickness is calculated from h_thin_max and h_thin_min (0.275 m)

One question:
the observational operator is defined inside the cs2SmosIce() function as two statements. Shall it rather be implemented as a separate function?