### PR TITLE
Change the restart.input_filename to make more sense.

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -6167,11 +6167,11 @@ FiniteElement::init()
 
     if ( M_use_restart )
     {
-        std::string resfil = vm["restart.input_filename"].as<std::string>();
-        LOG(DEBUG) <<"Reading restart file: [field,mesh]_"<< resfil <<".[bin,dat]\n";
-        if ( resfil.empty() )
-            throw std::runtime_error("Please provide restart.input_filename");
-        this->readRestart(resfil);
+        std::string res_str = vm["restart.basename"].as<std::string>();
+        LOG(DEBUG) <<"Reading restart file: [field,mesh]_"<< res_str <<".[bin,dat]\n";
+        if ( res_str.empty() )
+            throw std::runtime_error("Please provide restart.basename");
+        this->readRestart(res_str);
     }
     else
     {

--- a/model/options.cpp
+++ b/model/options.cpp
@@ -189,8 +189,8 @@ namespace Nextsim
                 "are we starting from a restart file?")
             ("restart.input_path", po::value<std::string>()->default_value( "" ),
                     "where to find restart files")
-            ("restart.input_filename", po::value<std::string>()->default_value( "" ),
-                "if we are starting from restart files, the files' names will be (restart.input_path)/{field|mesh}_(restart.filename).{bin,dat}")
+            ("restart.basename", po::value<std::string>()->default_value( "" ),
+                "The base of a restart file name. If we are starting from restart files, the files' names will be (restart.input_path)/{field|mesh}_(restart.basename).{bin,dat}")
             ("restart.type", po::value<std::string>()->default_value( "extend" ),
                 "Restart type: [extend|continue]. Extend (default): simul.time_init is taken as the time of restart and simul.duration is added to that. Continue: simul.time_init is read from the configuration file and duration is added to that.")
 


### PR DESCRIPTION
Just a minor change: I'd prefer restart.input_filename to be just the unique string (YYYYMMDDTHH:mmZ, final, or whatever), rather than field_"string" - makes more sense I think.