### PR TITLE
Fixes for the two problems in issue #303.

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -7574,7 +7574,7 @@ FiniteElement::initMoorings()
             output_time = M_current_time;
         else
             // shift the timestamp in the file to the centre of the output interval
-            output_time = M_current_time - double(mooring_output_time_step)/86400./2.;
+            output_time = M_current_time + double(mooring_output_time_step)/86400./2.;
 
         std::string filename_root;
         if ( M_moorings_parallel_output )
@@ -7616,7 +7616,7 @@ FiniteElement::updateMoorings()
         double not_used;
         if (       (M_rank==0 || M_moorings_parallel_output)
                 && (M_moorings_file_length != GridOutput::fileLength::inf)
-                && (modf(output_time, &not_used) < time_step*86400) )
+                && (modf(output_time, &not_used) < double(mooring_output_time_step)/86400) )
         {
             std::string filename_root;
             if ( M_moorings_parallel_output )

--- a/model/gridoutput.cpp
+++ b/model/gridoutput.cpp
@@ -769,11 +769,17 @@ GridOutput::initNetCDF(std::string file_prefix, fileLength file_length, double c
            filename << "_" << now.year() << "d" << setw(3) << setfill('0') << now.day_of_year();
            break;
        case fileLength::weekly:
-           // The last week of the year is troublesome!
-           // The boost library will (sometimes) give this the number 1, even though week 1 should be in January
+           // The last and first week of the year is troublesome!
+           /* ISO 8601 overlaps the weeks so that the last week of a year may
+            * extend into the new year and the first week of a year may begin
+            * before the new year. */
            if ( (now.month().as_number() == 12) && (now.week_number() == 1) )
            {
                filename << "_" << now.year() + 1 << "w" << setw(2) << setfill('0') << now.week_number();
+           }
+           else if ( (now.month().as_number() == 1) && (now.week_number() >= 52) )
+           {
+               filename << "_" << now.year() - 1 << "w" << setw(2) << setfill('0') << now.week_number();
            }
            else
            {


### PR DESCRIPTION
Problem 1 is solved by a simple shift of the output time during initialisation. This makes sense because at initialisation we need to add half the output time step, but at output it should be subtracted.

Problem 2 was due to incorrect formulation of the remainder calculation.

Testing revealed an issue with week numbering, which is also fixed here. This is because the ISO standard for week numbers says the last week of a year can extend into the next year - and this was not accounted for.

