### PR TITLE
Minor bug fix for interpCavities

### DIFF
--- a/contrib/bamg/src/InterpFromMeshToMesh2dCavities.cpp
+++ b/contrib/bamg/src/InterpFromMeshToMesh2dCavities.cpp
@@ -387,7 +387,7 @@ int DetectCavities(InterpFromMeshToMesh2dCavitiesThreadStruct* gate, BamgMesh* b
 
                     /* If NaN in matlab (0 after calling uint32)  */
                     if (std::isnan(Previous_connected_element))
-                        continue;
+                        break;
 
                     for (l=0; l<3; l++)
                     {


### PR DESCRIPTION
Change continue back to break. This is a reversal of commit 8970f9ab0b2a9c4c4e8e0a3785403f7756ef5470, which seems to have been a misinterpretation of the code following issue #174.