### PR TITLE
Issue330 joh dev compile

### DIFF
--- a/core/src/gmshmeshseq.cpp
+++ b/core/src/gmshmeshseq.cpp
@@ -397,7 +397,7 @@ GmshMeshSeq::initGModel()
 
     Msg::SetVerbosity(Environment::vm()["debugging.gmsh_verbose"].as<int>());
     CTX::instance()->terminal = 1;
-    //CTX::instance()->mesh.saveTopology = 0;
+    CTX::instance()->mesh.saveTopology = 0;
     CTX::instance()->mesh.fileFormat = FORMAT_MSH;
     CTX::instance()->mesh.mshFileVersion = 2.2;
     //M_partition_options.num_partitions = Environment::comm().size();


### PR DESCRIPTION
Code compiles in my docker, fram, maud, johansen. @einola, does it work in your docker?
- comment `saveTopology in gmshmeshseq` for now
- use `-isystem` instead of `-I` for external libraries where possible (unfortunately this needed a hack on maud since `NETCDF_DIR=/usr` and that caused problems with `/usr/include/stdlib.h`
- compile dependencies with `-MM` flag instead of `-M` so that it ignores `-isystem` directories