### PR TITLE
set output_time_step=0 if output.output_per_day<=0

### DIFF
--- a/core/src/gmshmeshseq.cpp
+++ b/core/src/gmshmeshseq.cpp
@@ -397,7 +397,7 @@ GmshMeshSeq::initGModel()
 
     Msg::SetVerbosity(Environment::vm()["debugging.gmsh_verbose"].as<int>());
     CTX::instance()->terminal = 1;
-    CTX::instance()->mesh.saveTopology = 0;
+   // CTX::instance()->mesh.saveTopology = 0;
     CTX::instance()->mesh.fileFormat = FORMAT_MSH;
     CTX::instance()->mesh.mshFileVersion = 2.2;
     //M_partition_options.num_partitions = Environment::comm().size();

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -1103,7 +1103,7 @@ FiniteElement::initOptAndParam()
     }
 #endif
 
-    output_time_step =  (vm["output.output_per_day"].as<int>()<0) ? time_step : time_step * floor(days_in_sec/vm["output.output_per_day"].as<int>()/time_step); //! \param output_time_step (int) Time step of model outputs
+    output_time_step =  (vm["output.output_per_day"].as<int>()<0) ? 0 : time_step * floor(days_in_sec/vm["output.output_per_day"].as<int>()/time_step); //! \param output_time_step (int) Time step of model outputs
 
     duration = (vm["simul.duration"].as<double>())*days_in_sec; //! \param duration (double) Duration of the simulation [s]
     if(duration<0)
@@ -7124,7 +7124,7 @@ FiniteElement::checkOutputs(bool const& at_init_time)
     }
 
     // check if we are outputting results file
-    if( pcpt*time_step % output_time_step == 0)
+    if( pcpt*time_step % output_time_step == 0 && output_time_step>0 )
     {
         chrono.restart();
         LOG(DEBUG) <<"export starts\n";

--- a/modules/enkf/perturbation/nml/pseudo2D.nml
+++ b/modules/enkf/perturbation/nml/pseudo2D.nml
@@ -7,7 +7,7 @@ ydim     = 360
 /
 
 &pseudo2D
-randf    = .true.
+randf    = .false.
 seed     = 11
 vslp     =  10
 vtaux    =  0.001


### PR DESCRIPTION
Stop daily outputs of field and mesh during a long time period run, if output.output_per_day<=0. Not affects mooring.
