### PR TITLE
set output_time_step=0 if output.output_per_day<=0

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -1103,7 +1103,7 @@ FiniteElement::initOptAndParam()
     }
 #endif
 
-    output_time_step =  (vm["output.output_per_day"].as<int>()<0) ? time_step : time_step * floor(days_in_sec/vm["output.output_per_day"].as<int>()/time_step); //! \param output_time_step (int) Time step of model outputs
+    output_time_step =  (vm["output.output_per_day"].as<int>()<=0) ? 0 : time_step * floor(days_in_sec/vm["output.output_per_day"].as<int>()/time_step); //! \param output_time_step (int) Time step of model outputs
 
     duration = (vm["simul.duration"].as<double>())*days_in_sec; //! \param duration (double) Duration of the simulation [s]
     if(duration<0)
@@ -7124,7 +7124,7 @@ FiniteElement::checkOutputs(bool const& at_init_time)
     }
 
     // check if we are outputting results file
-    if( pcpt*time_step % output_time_step == 0)
+    if( pcpt*time_step % output_time_step == 0 && output_time_step > 0)
     {
         chrono.restart();
         LOG(DEBUG) <<"export starts\n";


### PR DESCRIPTION
Hi @tdcwilliams 
It is easier to close the previous pull request and re-upload the branch.
Stop daily outputs of field and mesh during a long time period run, if output.output_per_day<=0. Not affects mooring.
