### PR TITLE
A hotfix for issue 392.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ model: core modules contrib
 core:
 	@cd $(NEXTSIMDIR)/core/src; $(MAKE)
 
-clean: cleandocker
+clean: cleanmodel
 	@cd $(NEXTSIMDIR)/contrib/bamg/src; $(MAKE) clean
 	@cd $(NEXTSIMDIR)/contrib/mapx/src; $(MAKE) clean
 ifdef USE_OASIS

--- a/README_docker.md
+++ b/README_docker.md
@@ -53,7 +53,7 @@ mounted directories. NB: the generated binary files will be available both for t
 
 If you want to recompile only the model code :
 ```
-docker run --rm -v `pwd`:/nextsim nextsim make cleandocker
+docker run --rm -v `pwd`:/nextsim nextsim make cleanmodel
 docker run --rm -v `pwd`:/nextsim nextsim make docker -j8
 ```
 


### PR DESCRIPTION
 The model now compiles in docker using the ``docker`` rule - as noted in the updated readme.

See also issue #392 