### PR TITLE
A fix to read the time dimension in a (much) more efficient manner.

### DIFF
--- a/model/externaldata.cpp
+++ b/model/externaldata.cpp
@@ -774,7 +774,7 @@ ExternalData::loadDataset(Dataset *dataset, std::vector<double> const& RX_in,
                     filename_prev = filename;
                 }
 
-                // The index above the courrent time
+                // The index above the current time
                 if ( indx_ceil >= 0 && indx_ceil < timeDim.getSize() )
                 {
                     index_start[0] = indx_ceil;


### PR DESCRIPTION
This pull request addresses issue #434 by reading the time dimension in a much more efficient manner. Instead of reading in the entire time vector and doing a linear search for the right place every time we now only read in the first two steps, infer the file's time step and from that read directly the correct record. This leads to a huge speed increase when reading in large datasets over a slow network (it halves the processing time on my local machine using ERA5 read in from johansen).

This assumes that time in the file is

- Monotonously increasing
- Evenly spaced

There are datasets in /Data/sim/data on johansen that don't adhere to this (in particular Sylvain's currents-from-altimeter dataset) - but we hardly use those anymore.