### PR TITLE
Catch unrealistic model states.

### DIFF
--- a/model/finiteelement.hpp
+++ b/model/finiteelement.hpp
@@ -925,6 +925,7 @@ private:
     void updateMoorings();
     void mooringsAppendNetcdf(double const &output_time);
     void checkFields();
+    void checkFieldsFast();
     void checkVelocityFields();
 
 };

--- a/model/options.cpp
+++ b/model/options.cpp
@@ -68,6 +68,8 @@ namespace Nextsim
                 "print out fields during checkFields() at this element number (local to M_rank = debugging.test_proc_number) (do nothing if <0)")
             ("debugging.check_velocity_fields", po::value<bool>()->default_value( false ),
                 "If check_velocity_fields is true: find outlier nodes with extreme velocities printed to DEBUG")
+            ("debugging.check_fields_fast", po::value<bool>()->default_value( true ),
+                "Do a quick sanity check on select fields. Export binary files and stop model if the check fails.")
 
              //-----------------------------------------------------------------------------------
              //! - Numerics


### PR DESCRIPTION
Address issue #466 

A simple checkFieldsFast that does a sanity check on a few fields and writes snapshots and restarts, and brings down the model on failure. It's fast enough that I leave it turned on by default.