### PR TITLE
The lower M_sst limit of check_fields_fast was too high

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -14187,7 +14187,7 @@ FiniteElement::checkFieldsFast()
             ("M_conc",       std::make_pair(   0.,  1.))
             ("M_damage",     std::make_pair(   0.,  1.))
             ("M_tice",       std::make_pair(-100.,  0.))
-            ("M_sst",        std::make_pair(  -3., 50.))
+            ("M_sst",        std::make_pair(  -5., 50.))
             ("M_sss",        std::make_pair(   0., 50.))
             ;
 


### PR DESCRIPTION
 - changing from -3 to -5 (see issue #470).