### PR TITLE
change default for thermo.use_assim_flux to false

### DIFF
--- a/model/options.cpp
+++ b/model/options.cpp
@@ -435,7 +435,7 @@ namespace Nextsim
                 "True: use total cloud cover parameterisation of long wave incoming radiation - only works if dataset has QLW_IN. False: use forcing from atmospheric datasets - only works if dataset has TCC")
 
             // -- assimilation compensating flux
-            ("thermo.use_assim_flux", po::value<bool>()->default_value(true),
+            ("thermo.use_assim_flux", po::value<bool>()->default_value(false),
              "Add a heat flux that compensates for assimilation of concentration")
             ("thermo.assim_flux_exponent", po::value<double>()->default_value(1.0),
              "Exponent of factor for heat flux that compensates for assimilation of concentration")


### PR DESCRIPTION
To avoid surprises when people use restarts from the forecast (when `M_conc_upd` is not-zero)