### PR TITLE
Fix the use of gmsh debugging when partitioning using disk

### DIFF
--- a/core/src/gmshmeshseq.cpp
+++ b/core/src/gmshmeshseq.cpp
@@ -532,7 +532,7 @@ GmshMeshSeq::partitionDisk(std::string const& mshfile,
             << " -string " << "\"Mesh.Partitioner="<< (int)partitioner <<";\""
             << " -string " << "\"Mesh.MetisAlgorithm="<< 2 <<";\"" // 1 = recursive (default), 2 = K-way
             << " -string " << "\"Mesh.MetisRefinementAlgorithm="<< 2 <<";\""
-            << " -string " << "\"General.Verbosity=0;\""
+            << " -string " << "\"General.Verbosity="<< Environment::vm()["debugging.gmsh_verbose"].as<int>() << ";\""
             << " " << mshfile;
 
     LOG(DEBUG) << "[Gmsh::generate] execute '" <<  gmshstr.str() << "'\n";

--- a/model/options.cpp
+++ b/model/options.cpp
@@ -52,7 +52,7 @@ namespace Nextsim
             ("debugging.bamg_verbose", po::value<int>()->default_value( 0 ),
                  "Bamg verbose mode: 0 is not verbose, 6 is very verbose")
             ("debugging.gmsh_verbose", po::value<int>()->default_value( 0 ),
-                 "Gmsh verbose mode: 0 is not verbose, 6 is very verbose")
+                 "Gmsh verbose mode: 0: silent except for fatal errors, 1: +errors, 2: +warnings, 3: +direct, 4: +information, 5: +status, 99: +debug")
             ("debugging.log-level", po::value<std::string>()->default_value( "info" ),
                 "Nextsim printouts. Options: debug, info, warning, error")
             ("debugging.log-all", po::value<bool>()->default_value( false ),


### PR DESCRIPTION
Address issue #513: Use the ``debugging.gmsh_verbose`` option also for the ``mesh.partitioner-space = disk`` option. Clarify better the values that can be given to gmsh_verbose.