### PR TITLE
Fix a lateral melt bug

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -6211,7 +6211,8 @@ FiniteElement::thermo(int dt)
         /* We conserve volume and energy */
         if ( M_conc[i] >= physical::cmin )
         {
-            hi = ( hi*old_conc + newice )/M_conc[i]; // TODO: Is it still valid with thin ice ?
+            // Spread newly formed ice or ridged thin ice on top of the old ice
+            hi += newice/M_conc[i];
             if ( del_c < 0. )
             {
                 /* We conserve the snow height, but melt away snow as the concentration decreases */


### PR DESCRIPTION
Fix a bug whereby lateral melt doesn't reduce ice volume, only concentration.

The old code conserved the ice volume, but this is not the right thing to do as we'd already taken lateral melt into account.