### PR TITLE
Add mesh displacement to the mesh position in GridOutput

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -7334,13 +7334,13 @@ FiniteElement::step()
             if ( M_use_moorings && !M_moorings_snapshot )
             {
                 M_timer.tick("updateGridMean");
-                M_moorings.updateGridMean(bamgmesh);
+                M_moorings.updateGridMean(bamgmesh, M_UM);
                 M_timer.tock("updateGridMean");
             }
 
 #ifdef OASIS
             M_timer.tick("updateGridMean_cpl");
-            M_cpl_out.updateGridMean(bamgmesh);
+            M_cpl_out.updateGridMean(bamgmesh, M_UM);
             M_timer.tock("updateGridMean_cpl");
 #endif
             LOG(DEBUG) <<"Regridding starts\n";
@@ -7552,7 +7552,7 @@ FiniteElement::step()
     this->updateMeans(M_cpl_out, cpl_time_factor);
     if ( pcpt*time_step % cpl_time_step == 0 )
     {
-        M_cpl_out.updateGridMean(bamgmesh);
+        M_cpl_out.updateGridMean(bamgmesh, M_UM);
 
         for (auto it=M_cpl_out.M_elemental_variables.begin(); it!=M_cpl_out.M_elemental_variables.end(); ++it)
         {
@@ -8557,7 +8557,7 @@ void
 FiniteElement::mooringsAppendNetcdf(double const &output_time)
 {
     // update data on grid
-    M_moorings.updateGridMean(bamgmesh);
+    M_moorings.updateGridMean(bamgmesh, M_UM);
 
     if ( ! M_moorings_parallel_output )
     {

--- a/model/gridoutput.hpp
+++ b/model/gridoutput.hpp
@@ -786,7 +786,7 @@ public:
 
     void setLSM(BamgMesh* bamgmesh);
 
-    void updateGridMean(BamgMesh* bamgmesh);
+    void updateGridMean(BamgMesh* bamgmesh, std::vector<double> & UM);
     void resetGridMean();
     void resetMeshMean(BamgMesh* bamgmesh, bool regrid, int nb_local_el,
             const std::vector<int>& gridP, const std::vector<std::vector<int>>& triangles, const std::vector<std::vector<double>>& weights);
@@ -850,7 +850,7 @@ private:
 
     void applyLSM();
 
-    void updateGridMeanWorker(BamgMesh* bamgmesh, variableKind kind, interpMethod method, std::vector<Variable>& variables, double miss_val);
+    void updateGridMeanWorker(BamgMesh* bamgmesh, std::vector<double> & UM, variableKind kind, interpMethod method, std::vector<Variable>& variables, double miss_val);
 
     void rotateVectors(Vectorial_Variable const& vectorial_variable, int nb_var, double* &interp_out, double miss_val);
 


### PR DESCRIPTION
As GridOutput only sees the BamgMesh object then it cannot take the mesh
displacement happening over a time step into account. This fix adds the
mesh displacement (M_UM) as an argument to the updateGrid calls of
GridOutput.

This addresses issue #552