### PR TITLE
Adressed issues related to compilation under GNU / Docker

### DIFF
--- a/env_compile_gnu_linux.bash
+++ b/env_compile_gnu_linux.bash
@@ -58,10 +58,14 @@ export FFLAGS="-O2 -fopenmp -lstdc++ -fPIC"
 #
 export MPI_DIR="/usr" ; # default OpenMPI
 #
+export NETCDF_DIR="/usr"
+export NETCDF_CXX_DIR="/usr"
+#
 export AEROBULK_DIR="${HOME}/DEV/aerobulk"
 export OASIS_DIR="${HOME}/src/oasis3-mct"
 #
 NXTSM_DEP_DIR="/opt/nextsim_gnu" ; # path to directory containing compiled BOOST and GMSH (with the relevant compiler!)
+#
 #############################################
 
 ######################################################################
@@ -69,6 +73,7 @@ NXTSM_DEP_DIR="/opt/nextsim_gnu" ; # path to directory containing compiled BOOST
 ######################################################################
 case `hostname | cut -d. -f2` in
     "ige-meom-cal1" ) NXTSM_DEP_DIR="/mnt/meom/workdir/brodeau/opt/nextsim_gnu"
+                      export AEROBULK_DIR="${NXTSM_DEP_DIR}/aerobulk"
                       ;;
     "occigen" )       NXTSM_DEP_DIR="/store/CT1/ige2071/brodeau/opt/nextsim_gnu"
                       ;;
@@ -80,6 +85,10 @@ case `hostname | cut -d. -f2` in
                       sleep 2
                       ;;
 esac
+
+if ${l_aerobulk} || ${l_cpl_oasis}; then
+    export LDFLAGS+="-lgfortran"
+fi
 
 # Normally the following 2 are pretty standard:
 export MPI_LIB_DIR=${MPI_DIR}/lib

--- a/env_compile_intel_linux.bash
+++ b/env_compile_intel_linux.bash
@@ -61,10 +61,14 @@ export INTEL_COMP_DIR="${INTEL_ROOT}/compiler/latest/linux";  #     "           
 #
 export MPI_DIR="${INTEL_ROOT}/mpi/latest"
 #
+export NETCDF_DIR="/opt/netcdf_intel"
+export NETCDF_CXX_DIR="/opt/netcdf_intel"
+#
 export AEROBULK_DIR="${HOME}/DEV/aerobulk"
 export OASIS_DIR="${HOME}/src/oasis3-mct"
 #
 NXTSM_DEP_DIR="/opt/nextsim_intel" ; # path to directory containing compiled BOOST and GMSH (with the relevant compiler!)
+#
 #############################################
 
 ######################################################################
@@ -120,6 +124,10 @@ case `hostname | cut -d. -f2` in
                       sleep 2
                       ;;
 esac
+
+if ${l_aerobulk} || ${l_cpl_oasis}; then
+    export LDFLAGS="-L${INTEL_COMP_DIR}/compiler/lib/intel64_lin -lifcore -lifport"
+fi
 
 # Normally the following 2 are pretty standard:
 export MPI_LIB_DIR=${MPI_DIR}/lib

--- a/model/Makefile
+++ b/model/Makefile
@@ -16,7 +16,7 @@ ifdef USE_OASIS
 	CXXFLAGS += -I$(NEXTSIMDIR)/modules/oasis/include
 	LDFLAGS += -L$(NEXTSIMDIR)/lib -loasis
 	CHAN = MPI1
-	LDFLAGS += -L$(OASIS_DIR)/lib -lpsmile.${CHAN} -lmct -lmpeu -lscrip $(LD_EXTRA_OASIS)
+	LDFLAGS += -L$(OASIS_DIR)/lib -lpsmile.$(CHAN) -lmct -lmpeu -lscrip $(LD_EXTRA_OASIS)
 endif
 
 ifneq (,$(strip $(filter DEBUG Debug debug PROFILE Profile profile,$(NEXTSIM_BUILD_TYPE))))
@@ -54,7 +54,10 @@ endif
 ifeq ($(NETCDF_FOR_DIR),)
 	NETCDF_FOR_DIR=$(NETCDF_DIR)
 endif
-LDFLAGS += -L$(NETCDF_DIR)/lib -lnetcdf -L$(NETCDF_CXX_DIR)/lib -lnetcdf_c++4 -L$(NETCDF_FOR_DIR)/lib -lnetcdff
+LDFLAGS += -L$(NETCDF_DIR)/lib -lnetcdf -L$(NETCDF_CXX_DIR)/lib -lnetcdf_c++4
+ifdef USE_OASIS
+	LDFLAGS += -L$(NETCDF_FOR_DIR)/lib -lnetcdff
+endif
 
 ifeq ($(NETCDF_DIR),/usr)
 	#needed for maud: need -I/usr/include otherwise have problems with stdlib.h


### PR DESCRIPTION
Adressed issues related to compilation under GNU (`-lnetcdff` & `-lgfortran`)

* `-lnetcdff` only called when `USE_OASIS` is set in `model/Makefile`
*  `-lgfortran` added to `LDFLAGS` in `env_compile_GNU_linux.bash` only if `l_aerobulk=true` or `l_cpl_oasis=true`
*  same with `-L${INTEL_COMP_DIR}/compiler/lib/intel64_lin -lifcore -lifport` in `env_compile_intel_linux.bash`