### PR TITLE
Coupling with waves no lateral melting

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -5602,7 +5602,7 @@ FiniteElement::thermo(int dt)
                 this->redistributeThermoFSD(i,ddt,lat_melt_rate,young_ice_growth,old_conc,old_conc_young);
             }
             /* In case there is melt_type!=3 (no FSD dependent lateral melting), FSD shape is unchanged.
-            FSD is updated after the routine is over (in step()) */
+            FSD is updated after the routine is over (in updateFSD(), called from step()) */
 #endif
         }
 


### PR DESCRIPTION
These are a few edits to be able to run neXtSIM coupled to a wave model (including an FSD) without having lateral melting 'on'.

What I call lateral melting is equivalent to setting melt_type==3. This activate a parameterization where the amount of lateral melting is related to the FSD.

With this branch, it is possible to use other melt_type without lateral melting, or at least a lateral melting that does not depend on the FSD. If melt occurs and M_conc /M_conc_young is reduced, the areal FSD is updated after the termo routine to account for changes in sea ice area, but its shape does not change.

