### PR TITLE
Remesh after reading restart if needed

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -6461,6 +6461,8 @@ FiniteElement::init()
         if ( res_str.empty() )
             throw std::runtime_error("Please provide restart.basename");
         this->readRestart(res_str);
+        if ( this->checkRegridding() )
+            this->regrid(pcpt); // The input for this function is no longer active
     }
     else
     {


### PR DESCRIPTION
This commit addresses issue #581, where OASIS would crash if the coupled
modelled is started from a restart where one (or more) of the triangle
angles is less than the critical angle (10 degrees, by default). In this
scenario the model asks OASIS for initial data, goes straight into the
remeshing and then asks for data again. OASIS doesn't like this second
request since it's being asked to give the same data twice and so brings
down the model.

Here we read in the restart file, check the angles and call the
``regrid`` function immediately if the angle is too small.