### PR TITLE
make checkFieldsFast less strict for M_h[s]_young

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -13569,11 +13569,9 @@ FiniteElement::checkFieldsFast()
 
     if(M_ice_cat_type==setup::IceCategoryType::YOUNG_ICE)
     {
-        double const h_young_max = vm["thermo.h_young_max"].as<double>();
-
         minmax.emplace("M_tsurf_young", std::make_pair(-100.,  0.));
-        minmax.emplace("M_h_young",     std::make_pair(   0.,  h_young_max));
-        minmax.emplace("M_hs_young",    std::make_pair(   0.,  h_young_max));
+        minmax.emplace("M_h_young",     std::make_pair(   0.,  2.));
+        minmax.emplace("M_hs_young",    std::make_pair(   0.,  2.));
         minmax.emplace("M_conc_young",  std::make_pair(   0.,  1.));
     }
 


### PR DESCRIPTION
Addresses #250 - crashing because `M_h_young` was slightly too high.
Originally thought the solution was to make sure young ice was put into old ice  after ridging in update,
but that was more complicated than originally thought (caused other crashes)  (and maybe should be thought about more in terms of ridging physics as well),  so instead just made `checkFieldsFast` a bit less strict.