### PR TITLE
rename cs2_smos input file (not using v2.2 anymore)

### DIFF
--- a/model/dataset.cpp
+++ b/model/dataset.cpp
@@ -6293,7 +6293,7 @@ DataSet::DataSet(char const *DatasetName)
             interpolation_method: InterpolationType::FromMeshToMesh2dx,
             interp_type: -1,
             dirname: "",
-            filename_mask: "cs2_smos_ice_thickness_%Y%m%d-fv2p2.nc",
+            filename_mask: "cs2_smos_ice_thickness_%Y%m%d.nc",
             gridfile: "",
             reference_date: "",
 


### PR DESCRIPTION
have updated linking script in `nextsim-env`:
https://github.com/nansencenter/nextsim-env/blob/master/data/process/link_CS2SMOS.py

and in `nextsimf` (new script `pynextsimf/scripts/link_init_data.py` from https://github.com/nansencenter/nextsimf/pull/288)