### PR TITLE
Issue549 topazfc update

### DIFF
--- a/model/dataset.cpp
+++ b/model/dataset.cpp
@@ -4666,7 +4666,7 @@ DataSet::DataSet(char const *DatasetName)
             use_FillValue: true,
             use_missing_value: true,
             a: 1.,
-            b: 12., // to center the time on the middle of the day
+            b: 0.,
             Units: "hours",
             loaded_data: loaded_data_tmp,
             interpolated_data: interpolated_data_tmp,
@@ -4859,7 +4859,7 @@ DataSet::DataSet(char const *DatasetName)
             use_FillValue: true,
             use_missing_value: true,
             a: 1.,
-            b: 12., // to center the time on the middle of the day
+            b: 0.,
             Units: "hours",
             loaded_data: loaded_data_tmp,
             interpolated_data: interpolated_data_tmp,


### PR DESCRIPTION
Closes #589.
- nextsim now takes in modified topaz forecast files
  - reprojected into the nextsim stereographic projection
  - depth dimension removed (with https://github.com/nansencenter/nextsim-env/blob/master/data/process/merge_topaz.py, which also selects the desired depth level) making the files much smaller

- also rename the cs2smos filename to remove the v2.2 suffix (uses any version from 2.2-2.4)