### PR TITLE
Fix glorys init

### DIFF
--- a/model/externaldata.cpp
+++ b/model/externaldata.cpp
@@ -766,6 +766,7 @@ ExternalData::loadDataset(Dataset *dataset, std::vector<double> const& RX_in,
     for (int fstep=0; fstep < nb_forcing_step; ++fstep) // always need one step before and one after the target time
     {
         // Load each variable and copy its data into loaded_data
+        int num_read=0;
         for(int j=0; j<dataset->variables.size(); ++j)
         {
             filename=filename_fstep[fstep];
@@ -873,8 +874,10 @@ ExternalData::loadDataset(Dataset *dataset, std::vector<double> const& RX_in,
             try
             {
                 NcVars[j].getVar(index_start,index_count,&data_in_tmp[0]);
+                // Keep a count of the variables actually read
+                num_read++;
             } catch (netCDF::exceptions::NcBadId) {
-                LOG(DEBUG) << "Not loading variable "<< j <<" (aka "<<
+                LOG(WARNING) << "Not loading variable "<< j <<" (aka "<<
                     dataset->variables[j].name <<") because I couldn't find it in the file "
                     << filename << "\n";
                 continue;
@@ -927,6 +930,8 @@ ExternalData::loadDataset(Dataset *dataset, std::vector<double> const& RX_in,
                 dataset->variables[j].loaded_data[fstep][i]=tmp_data_i;
             }
         }
+        // We may need to resize variables if not all variables were read
+        dataset->variables.resize(num_read);
     }
 
     dataset->nb_forcing_step=nb_forcing_step;


### PR DESCRIPTION
@docguibou asked 

> Is there a way to have a Dataset defined with like 5 variables
> Example
>  2605         std::vector<Variable> variables_tmp(5);
>  2606         variables_tmp[0] = sst;
>  2607         variables_tmp[1] = sss;
>  2608         variables_tmp[2] = mld;
>  2609         variables_tmp[3] = conc;
>  2610         variables_tmp[4] = thick;
> But that does not crash if a file only contains 3 of them?

This pull request addresses this (unregistered) issue by adding a ``try`` block around the call to read from the netCDF file and keeping count of how many variables are actually read.
