### PR TITLE
Address issue #612 by including an if-condition in model/Makefile

### DIFF
--- a/model/Makefile
+++ b/model/Makefile
@@ -45,7 +45,11 @@ ifdef USE_AEROBULK
 endif
 
 # boost
-CXXFLAGS += -isystem $(BOOST_INCDIR)/ -I.
+ifeq ($(BOOST_DIR),/usr)
+	CXXFLAGS += -I$(BOOST_INCDIR)/ -I.
+else
+	CXXFLAGS += -isystem $(BOOST_INCDIR)/ -I.
+endif
 
 # netcdf
 ifeq ($(NETCDF_CXX_DIR),)


### PR DESCRIPTION
The if-condition chooses to use either -isystem or -I, depending on the value of $BOOST_DIR. This is sub-optimal, but works. We should investigate better the use of -isystem.

See issue #612 