### PR TITLE
Set default diffusivity of SSS and SST to zero.

### DIFF
--- a/model/options.cpp
+++ b/model/options.cpp
@@ -405,8 +405,8 @@ namespace Nextsim
             ("thermo.drag_ocean_q", po::value<double>()->default_value( 1.5e-3 ), "")
 
             // -- diffusivity
-            ("thermo.diffusivity_sss", po::value<double>()->default_value( 100. ), "") //[m^2/s]
-            ("thermo.diffusivity_sst", po::value<double>()->default_value( 100. ), "") //[m^2/s]
+            ("thermo.diffusivity_sss", po::value<double>()->default_value( 0. ), "") //[m^2/s]
+            ("thermo.diffusivity_sst", po::value<double>()->default_value( 0. ), "") //[m^2/s]
 
             // -- relaxation of slab ocean to ocean forcing
             ("thermo.ocean_nudge_timeT", po::value<double>()->default_value( 30*days_in_sec),


### PR DESCRIPTION
Set the default diffusivity of SSS and SST to zero. Non-zero diffusivity is not needed and it impacts performance quite badly. As far as I know, most people (including myself) run with diffusion set to zero. Closes issue #623 