### PR TITLE
Add the option to output the consolidated ice fraction

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -8315,6 +8315,11 @@ FiniteElement::updateMeans(GridOutput& means, double time_factor)
                     it->data_mesh[i] += M_conc_young[i]*time_factor;
                 break;
 
+            case (GridOutput::variableID::conc_cons):
+                for (int i=0; i<M_local_nelements; i++)
+                    it->data_mesh[i] += M_conc[i]*time_factor;
+                break;
+
             case (GridOutput::variableID::h_young):
                 for (int i=0; i<M_local_nelements; i++)
                     it->data_mesh[i] += M_h_young[i]*time_factor;
@@ -8766,6 +8771,7 @@ FiniteElement::initMoorings()
             ("Qlh", GridOutput::variableID::Qlh)
             ("delS", GridOutput::variableID::delS)
             ("conc_young", GridOutput::variableID::conc_young)
+            ("conc_cons", GridOutput::variableID::conc_cons)
             ("h_young", GridOutput::variableID::h_young)
             ("hs_young", GridOutput::variableID::hs_young)
             ("sst", GridOutput::variableID::sst)

--- a/model/gridoutput.hpp
+++ b/model/gridoutput.hpp
@@ -225,6 +225,7 @@ public:
         fwflux_ice = 908,
         tauwix     = 909,
         tauwiy     = 910,
+        conc_cons  = 911,
 
         // Non-output variables - all negative
         proc_mask = -1,
@@ -355,6 +356,13 @@ public:
                     name     = "sic_young";
                     longName = "Sea Ice Area Fraction of Young Ice";
                     stdName  = "sea_ice_classification";
+                    Units    = "1";
+                    cell_methods = "area: mean";
+                    break;
+                case (variableID::conc_cons):
+                    name     = "sic_cons";
+                    longName = "Consolidated Ice Concentration";
+                    stdName  = "consolidated_ice_area_fraction";
                     Units    = "1";
                     cell_methods = "area: mean";
                     break;


### PR DESCRIPTION
This adds the consolidated ice fraction (aka thick ice concentration aka M_conc) to the moorings outputs. The point with this is to allow us to send this as a coupling variable, instead of the total ice concentration.