### PR TITLE
update env_compile_intel_linux.bash after fram update

### DIFF
--- a/env_compile_intel_linux.bash
+++ b/env_compile_intel_linux.bash
@@ -105,7 +105,15 @@ case `hostname -f | cut -d. -f2` in
                       #
                       export LDFLAGS="-L${INTEL_COMP_DIR}/compiler/lib/intel64_lin -lifcore -lifport"
                       ;;
-    "fram" )          NXTSM_DEP_DIR="/cluster/projects/nn9878k/guibou/nextsim_intel/opt/"
+    "fram" )          
+                      module --force purge
+                      ml load StdEnv
+                      ml load intel/2022a
+                      ml load HDF5/1.12.2-iimpi-2022a
+                      ml load netCDF-C++4/4.3.1-iimpi-2022a
+                      ml load ncview/2.1.8-iimpi-2022a
+                      ml load Boost.MPI/1.79.0-iimpi-2022a 
+                      NXTSM_DEP_DIR="/cluster/projects/nn9878k/nextsim_intel/opt/"
                       INTEL_VERSION="2022.1.0"
                       INTEL_ROOT="/cluster/software/intel-compilers/${INTEL_VERSION}"
                       export INTEL_COMP_DIR="/cluster/software/intel-compilers/${INTEL_VERSION}/compiler/latest/linux/"


### PR DESCRIPTION
I updated the env_compile_intel_linux.bash file created by Laurent to compile and run neXtSIM with intel. I managed to run nextsim stand-alone, nextsim-nemo and nextsim-ww3 on Fram with it.

It requires to load the following modules:

ml load intel/2022a
ml load HDF5/1.12.2-iimpi-2022a
ml load netCDF-C++4/4.3.1-iimpi-2022a
ml load ncview/2.1.8-iimpi-2022a
ml load Boost.MPI/1.79.0-iimpi-2022a