### PR TITLE
Parallelization of drifters except OSISAF

### DIFF
--- a/model/drifters.hpp
+++ b/model/drifters.hpp
@@ -180,7 +180,14 @@ public:
         //main interface to FiniteElement
         void updateDrifters(GmshMeshSeq const& movedmesh_root,
                 std::vector<double> & conc_root, double const& current_time);
+        void updateDrifters(GmshMesh const& movedmesh,
+                            std::vector<double> & conc, double const& current_time);
         void move(GmshMeshSeq const& mesh, std::vector<double> const& UT);
+        void move(GmshMesh const& mesh, std::vector<double> const& UT);
+
+        int inside(std::vector<double> const& points, double xp, double yp);
+        void find_partition(GmshMesh const& mesh, std::vector<double>& M_local_drifter_X, std::vector<double>& M_local_drifter_Y,
+                            std::vector<int>& M_triangle, std::vector<int>& M_nb_drifter);
 
 private:
         //initialising
@@ -212,10 +219,13 @@ private:
         void sortDrifterNumbers();
 
         //main ops
-        void reset(GmshMeshSeq const& moved_mesh, std::vector<double> & conc_root,
+        template<typename FEMeshType>
+        void reset(FEMeshType const& moved_mesh, std::vector<double> & conc,
                 double const& current_time);
         void updateConc( GmshMeshSeq const& moved_mesh,
                 std::vector<double> & conc, std::vector<double> & conc_drifters);
+        void updateConc(GmshMesh const& moved_mesh,
+                        std::vector<double> & conc, std::vector<double> &conc_drifters);
         bool resetting(double const& current_time)
         {
             if(!M_is_initialised)

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -8418,16 +8418,12 @@ void FiniteElement::checkMoveDrifters()
         return;
     LOG(DEBUG) << "Moving " << n_drifters << " drifters...\n";
 
-    //! - gather M_UT to root processor
-    std::vector<double> UT_root;
-    this->gatherNodalField(M_UT, UT_root);
-    std::fill(M_UT.begin(), M_UT.end(), 0.); // can now reset M_UT to 0
-    if(M_rank!=0)
-        return;
-
-    //! - move drifters on root processor
+    //! - move drifters on local processor
     for(auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
-        it->move(M_mesh_root, UT_root);
+        it->move(M_mesh, M_UT);
+
+    std::fill(M_UT.begin(), M_UT.end(), 0.); // can now reset M_UT to 0
+
 }//checkMoveDrifters
 
 
@@ -8455,19 +8451,35 @@ void FiniteElement::checkUpdateDrifters()
     // Move any active drifters
     this->checkMoveDrifters();
 
-    // Gather the fields needed by the drifters
-    std::vector<double> UM_root, conc_root;
-    this->gatherNodalField(M_UM, UM_root);
-    this->gatherElementField(M_conc, conc_root);
-    if(M_rank!=0)
+    n_update = 0;
+    for(auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
+        n_update += it->isInitialised();
+    boost::mpi::broadcast(M_comm, n_update, 0);
+
+    if (n_update == 0 || M_osisaf_drifters_indices.size() > 0)
+    {
+        // Gather the fields needed by the drifters
+        std::vector<double> UM_root, conc_root;
+        this->gatherNodalField(M_UM, UM_root);
+        this->gatherElementField(M_conc, conc_root);
+
+        if(M_rank!=0) return;
+
+        //updateDrifters does initialising, resetting, inputting,
+        //outputting (if needed)
+        auto movedmesh_root = M_mesh_root;
+        movedmesh_root.move(UM_root, 1.);
+        for(auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
+            it->updateDrifters(movedmesh_root, conc_root, M_current_time);
         return;
+    }
 
     //updateDrifters does initialising, resetting, inputting,
     //outputting (if needed)
-    auto movedmesh_root = M_mesh_root;
-    movedmesh_root.move(UM_root, 1.);
-    for(auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
-        it->updateDrifters(movedmesh_root, conc_root, M_current_time);
+    auto movedmesh = M_mesh;
+    movedmesh.move(M_UM, 1.);
+    for(auto it = M_drifters.begin(); it != M_drifters.end(); it++)
+        it->updateDrifters(movedmesh, M_conc, M_current_time);
 }//checkUpdateDrifters()
 
 


### PR DESCRIPTION
- Parallelization of the drifters:
   - Scatter the drifter list on the corresponding processor
   - Local interpolation of the total displacement on each drifter
   - Gather the new position of the drifters in the root process
   - The root process still remains the only one to know the drifter positions
   - Still need of the mesh_root initially for the first drifter update
   - Is not available for OSISAF drifters

- Modification of the maskXY function to avoid counting the number of occurrences when possible

For OSISAF, a extend of these modifications will be proposed after this PR.

Please, check this one with the different kinds of drifters as I do not have access to any drifter file so I tested this only with the uniform spaced drifters. However, the kind of drifters should not affect the results.
