### PR TITLE
Parallelization of drifters including OSISAF

### DIFF
--- a/model/drifters.hpp
+++ b/model/drifters.hpp
@@ -178,11 +178,8 @@ public:
         bool isInitialised() { return M_is_initialised; }
 
         //main interface to FiniteElement
-        void updateDrifters(GmshMeshSeq const& movedmesh_root,
-                std::vector<double> & conc_root, double const& current_time);
         void updateDrifters(GmshMesh const& movedmesh,
                             std::vector<double> & conc, double const& current_time);
-        void move(GmshMeshSeq const& mesh, std::vector<double> const& UT);
         void move(GmshMesh const& mesh, std::vector<double> const& UT);
 
         int inside(std::vector<double> const& points, double xp, double yp);
@@ -206,9 +203,9 @@ private:
             this->setTimingInfo(timing_info);
         }
 
-        void initialise(GmshMeshSeq const& moved_mesh, std::vector<double> & conc,
-                std::vector<double> & conc_drifters);
-        void initFromSpacing(GmshMeshSeq const& moved_mesh);
+        void initialise(GmshMesh const& moved_mesh, std::vector<double> & conc,
+                        std::vector<double> & conc_drifters);
+        void initFromSpacing(GmshMesh const& moved_mesh);
         void initFromTextFile();
         void initFromNetCDF();
         bool readFromRestart(
@@ -219,11 +216,8 @@ private:
         void sortDrifterNumbers();
 
         //main ops
-        template<typename FEMeshType>
-        void reset(FEMeshType const& moved_mesh, std::vector<double> & conc,
+        void reset(GmshMesh const& moved_mesh, std::vector<double> & conc,
                 double const& current_time);
-        void updateConc( GmshMeshSeq const& moved_mesh,
-                std::vector<double> & conc, std::vector<double> & conc_drifters);
         void updateConc(GmshMesh const& moved_mesh,
                         std::vector<double> & conc, std::vector<double> &conc_drifters);
         bool resetting(double const& current_time)

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -8451,29 +8451,6 @@ void FiniteElement::checkUpdateDrifters()
     // Move any active drifters
     this->checkMoveDrifters();
 
-    n_update = 0;
-    for(auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
-        n_update += it->isInitialised();
-    boost::mpi::broadcast(M_comm, n_update, 0);
-
-    if (n_update == 0 || M_osisaf_drifters_indices.size() > 0)
-    {
-        // Gather the fields needed by the drifters
-        std::vector<double> UM_root, conc_root;
-        this->gatherNodalField(M_UM, UM_root);
-        this->gatherElementField(M_conc, conc_root);
-
-        if(M_rank!=0) return;
-
-        //updateDrifters does initialising, resetting, inputting,
-        //outputting (if needed)
-        auto movedmesh_root = M_mesh_root;
-        movedmesh_root.move(UM_root, 1.);
-        for(auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
-            it->updateDrifters(movedmesh_root, conc_root, M_current_time);
-        return;
-    }
-
     //updateDrifters does initialising, resetting, inputting,
     //outputting (if needed)
     auto movedmesh = M_mesh;


### PR DESCRIPTION
The PR aims at removing the need of the M_mesh_root for drifters. This allows the use of parallel drifters even for the first step.

This makes possible to use OSISAF drifters in parallel.

The modifications have been tested for spaced drifters but not for OSISAF drifters.
