### PR TITLE
Debugging boost gather in drifters and ascii file in parallel writing

### DIFF
--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -14360,15 +14360,18 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
 
         MPI_File_close(&outbin);
 
-        fileout = filenames[1]+".dat";
-        LOG(VERBOSE) <<"RECORD FIELD: Exporter Filename= "<< fileout <<"\n";
-
-        std::fstream outrecord(fileout, std::ios::out | std::ios::trunc);
-        if ( !outrecord.good() )
-            throw std::runtime_error("Cannot write to file: " + fileout);
-
-        exporter.writeRecord(outrecord);
-        outrecord.close();
+        if (M_rank == 0)
+        {
+            fileout = filenames[1]+".dat";
+            LOG(VERBOSE) <<"RECORD FIELD: Exporter Filename= "<< fileout <<"\n";
+    
+            std::fstream outrecord(fileout, std::ios::out | std::ios::trunc);
+            if ( !outrecord.good() )
+                throw std::runtime_error("Cannot write to file: " + fileout);
+    
+            exporter.writeRecord(outrecord);
+            outrecord.close();
+        }
     }
 
 }// exportResults()


### PR DESCRIPTION
There are three proposed modifications here:

- There is a bug in the parallel drifters when there is no drifter in a partition. boost::gather, for some versions of boost at least, cannot deal with empty arrays. These boost functions have been replaced with send/recv MPI exchanges.

- There is an issue in parallel writing. The field.dat file was written by all the processors. When the root process is not the last one to write the file, the output file is empty. 

- I propose a new modification of the maskXY function. This does not correct a bug, but reduces significantly the computation time of this function, especially when using several millions of drifters. The use of the count function here was a bottleneck. Please check as this part of the function is only used with OSISAF drifters, so I could not check.