### PR TITLE
Update the boost timer reference

### DIFF
--- a/core/include/communicator.hpp
+++ b/core/include/communicator.hpp
@@ -10,7 +10,7 @@
 #define __Communicator_H 1
 
 #include <boost/mpi.hpp>
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 
 namespace Nextsim
 {


### PR DESCRIPTION
Using boost/timer.hpp finally throws an error (on the latest ubuntu lts). Switch to boost/timer/timer.hpp.

See issue #687