### PR TITLE
Update boost copy_file

### DIFF
--- a/model/drifters.cpp
+++ b/model/drifters.cpp
@@ -660,7 +660,7 @@ Drifters::backupOutputFile(std::string const& backup)
     if ( fs::exists(path1) )
     {
         fs::path path2(backup);
-        fs::copy_file(path1, path2, fs::copy_option::overwrite_if_exists);
+        fs::copy_file(path1, path2, fs::copy_options::overwrite_existing);
     }
 }//backupOutputFile()
 

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -14479,7 +14479,7 @@ FiniteElement::writeLogFile()
         if ( fs::exists(path1) )
         {
             fs::path path2(M_export_path+ "/" + path1.filename().string());
-            fs::copy_file(path1, path2, fs::copy_option::overwrite_if_exists);
+            fs::copy_file(path1, path2, fs::copy_options::overwrite_existing);
         }
     }
 }//writeLogFile


### PR DESCRIPTION
Boost's copy_option was replaced with copy_options. The latest boost version refuses to compile the old code - hence the update.

See issue #697 