### PR TITLE
Revert parallel export

### DIFF
--- a/core/include/exporter.hpp
+++ b/core/include/exporter.hpp
@@ -36,8 +36,8 @@ public:
     template<typename Type>
     void writeContainer(std::fstream& out, std::vector<Type> const& container, std::string const precision);
 
-    void writeMesh(std::fstream& out, GmshMesh const& Mesh);
-    void writeMesh(std::fstream& out, GmshMeshSeq const& Mesh);
+    template<typename FEMeshType>
+    void writeMesh(std::fstream& out, FEMeshType const& Mesh);
     template<typename Type>
 	void writeMesh(std::fstream& out, std::vector<Type> const& xnod, std::vector<Type> const& ynod,
             std::vector<int> const& idnod, std::vector<int> const& elements);

--- a/core/include/exporter.hpp
+++ b/core/include/exporter.hpp
@@ -36,29 +36,14 @@ public:
     template<typename Type>
     void writeContainer(std::fstream& out, std::vector<Type> const& container, std::string const precision);
 
-    template<typename Type>
-    void writeContainer(MPI_File& out, std::vector<Type> const& container, int is_vector, Communicator M_comm, MPI_Offset& base_offset, std::string const precision);
-
-    template<typename Type>
-    void orderField(std::vector<Type> const& field_local, std::vector<Type>& ordered_field, std::vector<int>& rmap, 
-                        Communicator M_comm, int local_ndof, int num_nodes);
-
-    void writeMesh(MPI_File& out, GmshMesh const& Mesh, std::vector<int>& rmap_nodes, std::vector<int>& rmap_elements);
+    void writeMesh(std::fstream& out, GmshMesh const& Mesh);
     void writeMesh(std::fstream& out, GmshMeshSeq const& Mesh);
     template<typename Type>
 	void writeMesh(std::fstream& out, std::vector<Type> const& xnod, std::vector<Type> const& ynod,
             std::vector<int> const& idnod, std::vector<int> const& elements);
-    template<typename Type>
-    void writeMesh(MPI_File& out, std::vector<Type> const &xnod, std::vector<Type> const &ynod,
-                   std::vector<int> const &idnod, std::vector<int> const &elements, Communicator M_comm);
 
     template<typename Type>
-	void writeField(MPI_File& out, std::vector<Type> const& field, std::string const& name, Communicator M_comm, 
-                    MPI_Offset& base_offset, std::vector<int>& rmap, int local_ndof, int num_nodes, int root);
-
-    template<typename Type>
-    void writeField(std::fstream& out, std::vector<Type> const& field, std::string const& name);
-
+	void writeField(std::fstream& out, std::vector<Type> const& field, std::string const& name);
 	void writeRecord(std::fstream& out, std::string const& rtype = "field");
 
     void loadFile(std::fstream &in, boost::unordered_map<std::string, std::vector<int>> &field_map_int, boost::unordered_map<std::string, std::vector<double>> &field_map_dbl);

--- a/core/include/exporter.hpp
+++ b/core/include/exporter.hpp
@@ -31,7 +31,7 @@ class Exporter
 {
 public:
 
-	Exporter();
+	Exporter(std::string const& precision = "float");
 
     template<typename Type>
     void writeContainer(std::fstream& out, std::vector<Type> const& container, std::string const precision);
@@ -53,8 +53,11 @@ public:
                    std::vector<int> const &idnod, std::vector<int> const &elements, Communicator M_comm);
 
     template<typename Type>
-	void writeField(MPI_File& out, std::vector<Type> const& field, std::string const& name, std::string const& precision,
-            Communicator M_comm, MPI_Offset& base_offset, std::vector<int>& rmap, int local_ndof, int num_nodes, int root);
+	void writeField(MPI_File& out, std::vector<Type> const& field, std::string const& name, Communicator M_comm, 
+                    MPI_Offset& base_offset, std::vector<int>& rmap, int local_ndof, int num_nodes, int root);
+
+    template<typename Type>
+    void writeField(std::fstream& out, std::vector<Type> const& field, std::string const& name);
 
 	void writeRecord(std::fstream& out, std::string const& rtype = "field");
 
@@ -69,6 +72,8 @@ private:
     //std::vector<int> M_type_record;
     std::vector<std::string> M_type_record;
     std::vector<std::string> M_name_record;
+
+    std::string M_precision;
 };
 } // Nextsim
 #endif

--- a/core/src/exporter.cpp
+++ b/core/src/exporter.cpp
@@ -59,113 +59,9 @@ Exporter::writeContainer(std::fstream& out, std::vector<Type> const& container, 
 	}
 }
 
+template<typename FEMeshType>
 void
-Exporter::writeMesh(std::fstream& out, GmshMesh const& Mesh)
-{
-    Communicator M_comm = Mesh.comm();
-
-    std::vector<double> coordX = Mesh.coordXPartition();
-    std::vector<double> coordY = Mesh.coordYPartition();
-    std::vector<int> indexTr = Mesh.indexTrPartition();
-    std::vector<int> id = Mesh.id();
-
-    std::vector<double> coordX_root, coordY_root;
-    std::vector<int> indexTr_root, id_root;
-    std::vector<int> id_ghost(Mesh.numGlobalNodes()+1);
-
-    std::vector<int> size_elements;
-    boost::mpi::all_gather(M_comm, 3*Mesh.numTrianglesWithoutGhost(), size_elements);
-
-    std::vector<int> size_nodes;
-    boost::mpi::all_gather(M_comm, Mesh.numLocalNodesWithoutGhost(), size_nodes);
-
-    std::vector<int> displs(M_comm.size());
-    displs[0] = 0;
-    for ( int k = 1; k < M_comm.size(); k++ ) {
-        displs[k] = displs[k-1] + size_nodes[k-1];
-    }
-
-    if (M_comm.rank() == 0)
-    {
-        coordX_root.resize(Mesh.numGlobalNodes());
-        coordY_root.resize(Mesh.numGlobalNodes());
-        indexTr_root.resize(3*Mesh.numGlobalElements());
-        id_root.resize(Mesh.numGlobalNodes());
-    }
-
-    // Gather coordinates and id
-    int ier = MPI_Gatherv(&coordX[0], Mesh.numLocalNodesWithoutGhost(), MPI_DOUBLE, &coordX_root[0], &size_nodes[0], &displs[0], MPI_DOUBLE, 0, MPI_Comm(M_comm));
-    ier = MPI_Gatherv(&coordY[0], Mesh.numLocalNodesWithoutGhost(), MPI_DOUBLE, &coordY_root[0], &size_nodes[0], &displs[0], MPI_DOUBLE, 0, MPI_Comm(M_comm));
-    ier = MPI_Gatherv(&id[0], Mesh.numLocalNodesWithoutGhost(), MPI_INT, &id_root[0], &size_nodes[0], &displs[0], MPI_INT, 0, MPI_Comm(M_comm));
-
-    if (M_comm.rank() == 0)
-    {
-        for (int k = 0; k < Mesh.numGlobalNodes(); k++) id_ghost[id_root[k]] = k;
-    }
-
-    boost::mpi::broadcast(M_comm, &id_ghost[0], Mesh.numGlobalNodes()+1, 0);
-
-    // Correct the indices in the triangles
-    std::map<int, Nextsim::entities::GMSHPoint > nodes = Mesh.nodes();
-    for (int k = 0; k < 3*Mesh.numTrianglesWithoutGhost(); k++)
-    {
-        if (indexTr[k] <= Mesh.numLocalNodesWithoutGhost())
-        {
-            indexTr[k] += displs[M_comm.rank()];
-        }
-        else // it is a ghost that belongs to another partition
-        {
-            indexTr[k] = id_ghost[nodes.find(indexTr[k])->second.id]+1;
-        }
-    }
-
-    // Gather triangle indices
-    displs[0] = 0;
-    for (int k = 1; k < M_comm.size(); k++) displs[k] = displs[k-1] + size_elements[k-1];
-
-    ier = MPI_Gatherv(&indexTr[0], 3*Mesh.numTrianglesWithoutGhost(), MPI_INT, &indexTr_root[0], &size_elements[0], &displs[0], MPI_INT, 0, MPI_Comm(M_comm));
-
-    if (M_comm.rank() == 0)
-    {
-        std::vector<double> coordX_out(Mesh.numGlobalNodes());
-        std::vector<double> coordY_out(Mesh.numGlobalNodes());
-        std::vector<int> indexTr_out(indexTr_root.size());
-        std::vector<int> id_out(Mesh.numGlobalNodes());
-        std::vector<int> node_correspondence(Mesh.numGlobalNodes());
-
-        std::vector<int> M_rmap_nodes = Mesh.mapNodes();
-        std::vector<int> M_rmap_elements = Mesh.mapElements();
-
-        // Reorder nodes to correspond to the node fields
-        for (int i = 0; i < Mesh.numGlobalNodes(); ++i)
-        {
-            int ri =  M_rmap_nodes[i];
-            node_correspondence[ri] = i;
-
-            coordX_out[i] = coordX_root[ri];
-            coordY_out[i] = coordY_root[ri];
-            id_out[i] = id_root[ri];
-        }
-
-        for (int i = 0; i < indexTr_root.size(); i++) indexTr_out[i] = node_correspondence[indexTr_root[i]-1]+1;
-
-        // Reorder the elements to correspond to the element fields
-        auto indexTr_out_cpy = indexTr_out;
-
-        for (int i = 0; i < indexTr_root.size(); i++)
-        {
-            int ri = M_rmap_elements[i/3];
-            indexTr_out[i] = indexTr_out_cpy[3*ri+i%3];
-        }
-
-        // Write the mesh
-        this->writeMesh(out, coordX_out, coordY_out, id_out, indexTr_out);
-    }
-
-}
-
-void
-Exporter::writeMesh(std::fstream& out, GmshMeshSeq const& Mesh)
+Exporter::writeMesh(std::fstream& out, FEMeshType const& Mesh)
 {
     auto xnod = Mesh.coordX();
     auto ynod = Mesh.coordY();
@@ -325,6 +221,9 @@ Exporter::loadFile(std::fstream &in, boost::unordered_map<std::string, std::vect
 
 template void Exporter::writeField<double>(std::fstream&, std::vector<double> const&, std::string const&);
 template void Exporter::writeField<int>(std::fstream&, std::vector<int> const&, std::string const&);
+
+template void Exporter::writeMesh(std::fstream&, GmshMesh const& Mesh);
+template void Exporter::writeMesh(std::fstream&, GmshMeshSeq const& Mesh);
 
 template void Exporter::writeMesh<double>(std::fstream&, std::vector<double> const&, std::vector<double> const&,
         std::vector<int> const&,std::vector<int> const&);

--- a/core/src/exporter.cpp
+++ b/core/src/exporter.cpp
@@ -12,13 +12,20 @@
 
 namespace Nextsim
 {
-Exporter::Exporter()
+Exporter::Exporter(std::string const& precision)
 	:
 	M_mrecord(),
     M_frecord(),
     M_type_record(),
-    M_name_record()
-{}
+    M_name_record(),
+    M_precision(precision)
+{
+    if ( precision != "double" & precision != "float" & precision != "int" )
+    {
+        std::string error_str = "Exporter: Unknown precision: " + precision;
+        throw std::logic_error(error_str);
+    }
+}
 
 // writeContainer in sequential
 template<typename Type>
@@ -486,20 +493,24 @@ Exporter::writeMesh(std::fstream& out, std::vector<Type> const &xnod, std::vecto
 //writeField in parallel
 template<typename Type>
 void
-Exporter::writeField(MPI_File& out, std::vector<Type> const& field, std::string const& name, std::string const& precision, Communicator M_comm, 
+Exporter::writeField(MPI_File& out, std::vector<Type> const& field, std::string const& name, Communicator M_comm, 
                      MPI_Offset& base_offset, std::vector<int>& rmap, int size_without_ghost, int num_nodes, int root)
 {
     std::string description;
+    std::string precision;
+
+    if (((boost::any)field[0]).type() == typeid(int))
+        precision = "int";
+    else
+        precision = M_precision;
+
+    if (name == "Time") precision = "double";
 
     MPI_Datatype mpi_type;
     size_t elem_size = 0;
     if (precision == "float")      { mpi_type = MPI_FLOAT;  elem_size = sizeof(float); }
     else if (precision == "double"){ mpi_type = MPI_DOUBLE; elem_size = sizeof(double); }
     else if (precision == "int")   { mpi_type = MPI_INT;    elem_size = sizeof(int); }
-    else {
-        std::string const error_str = "Exporter: Unknown precision: " + precision;
-        throw std::logic_error(error_str);
-    }
 
     // For the fields written only by the root process
     if (root)
@@ -566,6 +577,34 @@ Exporter::writeField(MPI_File& out, std::vector<Type> const& field, std::string 
 
 }//writeField
 
+//writeField sequentially
+template<typename Type>
+void
+Exporter::writeField(std::fstream& out, std::vector<Type> const& field, std::string const& name)
+{
+    std::string description;
+
+    std::string precision;
+    // We must choose either integer or floating point
+    if (((boost::any)field[0]).type() == typeid(int))
+        precision = "int";
+    else
+        precision = M_precision;
+
+    // Time should always be in double
+    if ( name == "Time" )
+        precision = "double";
+
+    writeContainer(out, field, precision);
+    description = (boost::format( "%1% %2% %3$g %4$g %5$g" )
+                   % name
+                   % precision
+                   % field.size()
+                   % ( (field.size() > 0) ? *std::min_element(field.begin(), field.end()) : 0 ) 
+                   % ( (field.size() > 0) ? *std::max_element(field.begin(), field.end()) : 0 ) ).str();
+
+    M_frecord.push_back(description);
+}
 
 void
 Exporter::writeRecord(std::fstream& out, std::string const& rtype)
@@ -635,10 +674,12 @@ Exporter::loadFile(std::fstream &in, boost::unordered_map<std::string, std::vect
     }
 }
 
+template void Exporter::writeField<double>(std::fstream&, std::vector<double> const&, std::string const&);
+template void Exporter::writeField<int>(std::fstream&, std::vector<int> const&, std::string const&);
 
-template void Exporter::writeField(MPI_File& out, std::vector<double> const& field, std::string const& name, std::string const& precision, Communicator M_comm,
+template void Exporter::writeField(MPI_File& out, std::vector<double> const& field, std::string const& name, Communicator M_comm, 
                                    MPI_Offset& base_offset, std::vector<int>& rmap, int size_without_ghost, int num_nodes, int root);
-template void Exporter::writeField(MPI_File& out, std::vector<int> const& field, std::string const& name, std::string const& precision, Communicator M_comm,
+template void Exporter::writeField(MPI_File& out, std::vector<int> const& field, std::string const& name, Communicator M_comm, 
                                    MPI_Offset& base_offset, std::vector<int>& rmap, int size_without_ghost, int num_nodes, int root);
 
 template void Exporter::writeMesh<double>(std::fstream&, std::vector<double> const&, std::vector<double> const&,

--- a/core/src/exporter.cpp
+++ b/core/src/exporter.cpp
@@ -27,7 +27,6 @@ Exporter::Exporter(std::string const& precision)
     }
 }
 
-// writeContainer in sequential
 template<typename Type>
 void
 Exporter::writeContainer(std::fstream& out, std::vector<Type> const& container, std::string const precision)
@@ -60,198 +59,23 @@ Exporter::writeContainer(std::fstream& out, std::vector<Type> const& container, 
 	}
 }
 
-// writeContainer with parallel writing
-template<typename Type>
 void
-Exporter::writeContainer(MPI_File& out, std::vector<Type> const& container, int is_vector, 
-                         Communicator M_comm, MPI_Offset& base_offset, std::string const precision)
-{
-    int fsize = container.size();
-    int global_fsize;
-    boost::mpi::all_reduce(M_comm, fsize, global_fsize, std::plus<int>());
-
-    // Write the size only on rank 0
-    if (M_comm.rank() == 0) MPI_File_write_at(out, base_offset, &global_fsize, 1 ,MPI_INT, MPI_STATUS_IGNORE);
-
-    // Offset is the location to write in the output file
-    MPI_Offset offset = static_cast<MPI_Offset>(sizeof(global_fsize)) + base_offset;
-
-    MPI_Datatype mpi_type;
-    size_t elem_size = 0;
-    if (precision == "float")      { mpi_type = MPI_FLOAT;  elem_size = sizeof(float); }
-    else if (precision == "double"){ mpi_type = MPI_DOUBLE; elem_size = sizeof(double); }
-    else if (precision == "int")   { mpi_type = MPI_INT;    elem_size = sizeof(int); }
-
-    if (!is_vector)
-    {
-        // Find the offset for each processor
-        int offset_count = 0;
-        MPI_Exscan(&fsize, &offset_count, 1, MPI_INT, MPI_SUM, MPI_Comm(M_comm));
-        if (M_comm.rank() == 0) offset_count = 0;
-
-        offset += static_cast<MPI_Offset>(offset_count) * elem_size;
-
-        std::vector<float> fvalues(fsize);
-        if (precision == "float") {
-            for (int i=0; i<fsize; ++i) fvalues[i] = (float)container[i];
-            MPI_File_write_at(out, offset, fvalues.data(), fsize, mpi_type, MPI_STATUS_IGNORE);
-        }
-        else MPI_File_write_at(out, offset, container.data(), fsize, mpi_type, MPI_STATUS_IGNORE);
-
-        base_offset += sizeof(global_fsize) + global_fsize * elem_size;
-
-        return;
-    }
-
-    // else, the container is a vector with two components
-    // it must be diveded in two parts and write separatly
-    int fsize2 = fsize/2;
-    int offset_count1 = 0;
-    MPI_Exscan(&fsize2, &offset_count1, 1, MPI_INT, MPI_SUM, MPI_Comm(M_comm));
-    if (M_comm.rank() == 0) offset_count1 = 0;
-
-    offset += static_cast<MPI_Offset>(offset_count1) * elem_size;
-
-    if (precision == "float")
-    {
-        std::vector<float> fvalues(fsize2);
-        for (int i=0; i<fsize2; ++i) fvalues[i] = (float)container[2*i];
-        MPI_File_write_at(out, offset, fvalues.data(), fsize2, mpi_type, MPI_STATUS_IGNORE);
-    }
-    else
-    {
-        std::vector<Type> fvalues(fsize2);
-        for (int i=0; i<fsize2; ++i) fvalues[i] = container[2*i];
-        MPI_File_write_at(out, offset, fvalues.data(), fsize2, mpi_type, MPI_STATUS_IGNORE);
-    }
-
-    MPI_Offset offset2 = static_cast<MPI_Offset>(sizeof(global_fsize)) + base_offset +
-                         (global_fsize/2) * elem_size +
-                         static_cast<MPI_Offset>(offset_count1) * elem_size;
-
-    if (precision == "float")
-    {
-        std::vector<float> fvalues(fsize2);
-        for (int i=0; i<fsize2; ++i) fvalues[i] = (float)container[2*i+1];
-        MPI_File_write_at(out, offset2, fvalues.data(), fsize2, mpi_type, MPI_STATUS_IGNORE);
-    }
-    else
-    {
-        std::vector<Type> fvalues(fsize2);
-        for (int i=0; i<fsize2; ++i) fvalues[i] = container[2*i+1];
-        MPI_File_write_at(out, offset2, fvalues.data(), fsize2, mpi_type, MPI_STATUS_IGNORE);
-    }
-
-    // Update the base offset for the next fields to write in the same file
-    base_offset += sizeof(global_fsize) + global_fsize * elem_size;
-
-} //writeContainer
-
-template<typename Type>
-void
-Exporter::orderField(std::vector<Type> const& field_local, std::vector<Type>& ordered_field, std::vector<int>& rmap, 
-                     Communicator M_comm, int size_without_ghost, int num_nodes)
-{
-    int is_vector = 0;
-    if (field_local.size() == 2*num_nodes) is_vector = 1;
-
-    std::vector<int> rcounts(M_comm.size());
-    boost::mpi::all_gather(M_comm, size_without_ghost, rcounts);
-    std::vector<int> displs(M_comm.size());
-    displs[0] = 0;
-    for ( int k = 1; k < M_comm.size(); k++ ) {
-        displs[k] = displs[k-1] + rcounts[k-1];
-    }
-
-    std::vector<std::vector<int>> list_indices_recv(M_comm.size());
-    for (int i = 0; i < size_without_ghost; i++)
-    {
-        int ri = rmap[displs[M_comm.rank()] + i];
-        int j = 0;
-        while (j < M_comm.size()-1 && ri >= displs[j+1]) j++;
-
-        if (j == M_comm.rank())
-        {
-            if (is_vector)
-            {
-                ordered_field[2*i] = field_local[ri - displs[M_comm.rank()]];
-                ordered_field[2*i+1] = field_local[ri - displs[M_comm.rank()] + num_nodes];
-            }
-            else ordered_field[i] = field_local[ri - displs[M_comm.rank()]];
-            continue;
-        }
-
-        list_indices_recv[j].push_back(displs[M_comm.rank()] + i);
-    }
-
-    std::vector<boost::mpi::request> requests;
-    std::vector<std::vector<int>> list_indices_send(M_comm.size());
-    for (int i = 0; i < M_comm.size(); i++)
-    {
-        requests.push_back(M_comm.isend(i, M_comm.rank(), list_indices_recv[i]));
-        requests.push_back(M_comm.irecv(i, i, list_indices_send[i]));
-    }
-    boost::mpi::wait_all(requests.begin(), requests.end());
-    requests.clear();
-
-    std::vector<std::vector<Type>> field_send(M_comm.size());
-    for (int i = 0; i < M_comm.size(); i++)
-    {
-        for (int j = 0; j < list_indices_send[i].size(); j++)
-        {
-            field_send[i].push_back(field_local[rmap[list_indices_send[i][j]] - displs[M_comm.rank()]]);
-            if (is_vector) field_send[i].push_back(field_local[rmap[list_indices_send[i][j]] - displs[M_comm.rank()] + num_nodes]);
-        }
-    }
-
-    std::vector<std::vector<Type>> field_recv(M_comm.size());
-    for (int i = 0; i < M_comm.size(); i++)
-    {
-        requests.push_back(M_comm.isend(i, M_comm.rank(), field_send[i]));
-        requests.push_back(M_comm.irecv(i, i, field_recv[i]));
-    }
-    boost::mpi::wait_all(requests.begin(), requests.end());
-
-    for (int i = 0; i < M_comm.size(); i++)
-    {
-        if (M_comm.rank() == i) continue;
-
-        for (int j = 0; j < list_indices_recv[i].size(); j++)
-        {
-            if (is_vector)
-            {
-                ordered_field[2*(list_indices_recv[i][j]-displs[M_comm.rank()])] = field_recv[i][2*j];
-                ordered_field[2*(list_indices_recv[i][j]-displs[M_comm.rank()])+1] = field_recv[i][2*j+1];
-            }
-            else ordered_field[list_indices_recv[i][j]-displs[M_comm.rank()]] = field_recv[i][j];
-        }
-    }
-
-}//orderField
-
-// writeMesh function in parallel
-void
-Exporter::writeMesh(MPI_File& out, GmshMesh const& Mesh, std::vector<int>& rmap_nodes, std::vector<int>& rmap_elements)
+Exporter::writeMesh(std::fstream& out, GmshMesh const& Mesh)
 {
     Communicator M_comm = Mesh.comm();
 
-    // Local 
     std::vector<double> coordX = Mesh.coordXPartition();
     std::vector<double> coordY = Mesh.coordYPartition();
     std::vector<int> indexTr = Mesh.indexTrPartition();
     std::vector<int> id = Mesh.id();
-    int num_nodes = coordX.size();
-    id.resize(num_nodes); // Remove ghosts
 
-    // Global coordinates
-    std::vector<double> coordX_out(num_nodes);
-    std::vector<double> coordY_out(num_nodes);
-    std::vector<int> id_out(num_nodes);
-    orderField(coordX, coordX_out, rmap_nodes, M_comm, num_nodes, 0);
-    orderField(coordY, coordY_out, rmap_nodes, M_comm, num_nodes, 0);
-    orderField(id, id_out, rmap_nodes, M_comm, num_nodes, 0);
+    std::vector<double> coordX_root, coordY_root;
+    std::vector<int> indexTr_root, id_root;
+    std::vector<int> id_ghost(Mesh.numGlobalNodes()+1);
 
-    // Global indices of triangles
+    std::vector<int> size_elements;
+    boost::mpi::all_gather(M_comm, 3*Mesh.numTrianglesWithoutGhost(), size_elements);
+
     std::vector<int> size_nodes;
     boost::mpi::all_gather(M_comm, Mesh.numLocalNodesWithoutGhost(), size_nodes);
 
@@ -261,26 +85,28 @@ Exporter::writeMesh(MPI_File& out, GmshMesh const& Mesh, std::vector<int>& rmap_
         displs[k] = displs[k-1] + size_nodes[k-1];
     }
 
-    std::vector<int> id_root(Mesh.numGlobalNodes());
-    std::vector<int> id_ghost(Mesh.numGlobalNodes()+1);
-    int ier = MPI_Allgatherv(&id[0], Mesh.numLocalNodesWithoutGhost(), MPI_INT, &id_root[0], 
-                             &size_nodes[0], &displs[0], MPI_INT, MPI_Comm(M_comm));
-
-    for (int k = 0; k < Mesh.numGlobalNodes(); k++) id_ghost[id_root[k]] = k;
-
-    // Correct the local indices in the triangles to have global indices
-    std::map<int, Nextsim::entities::GMSHPoint > nodes = Mesh.nodes();
-    auto it = nodes.begin();
-    std::advance(it, num_nodes);
-
-    std::vector<int> id_local_ghost(Mesh.numNodes() - num_nodes);
-    int cpt = 0;
-    for (; it != nodes.end(); ++it)
+    if (M_comm.rank() == 0)
     {
-        id_local_ghost[cpt] = it->second.id;
-        ++cpt;
+        coordX_root.resize(Mesh.numGlobalNodes());
+        coordY_root.resize(Mesh.numGlobalNodes());
+        indexTr_root.resize(3*Mesh.numGlobalElements());
+        id_root.resize(Mesh.numGlobalNodes());
     }
 
+    // Gather coordinates and id
+    int ier = MPI_Gatherv(&coordX[0], Mesh.numLocalNodesWithoutGhost(), MPI_DOUBLE, &coordX_root[0], &size_nodes[0], &displs[0], MPI_DOUBLE, 0, MPI_Comm(M_comm));
+    ier = MPI_Gatherv(&coordY[0], Mesh.numLocalNodesWithoutGhost(), MPI_DOUBLE, &coordY_root[0], &size_nodes[0], &displs[0], MPI_DOUBLE, 0, MPI_Comm(M_comm));
+    ier = MPI_Gatherv(&id[0], Mesh.numLocalNodesWithoutGhost(), MPI_INT, &id_root[0], &size_nodes[0], &displs[0], MPI_INT, 0, MPI_Comm(M_comm));
+
+    if (M_comm.rank() == 0)
+    {
+        for (int k = 0; k < Mesh.numGlobalNodes(); k++) id_ghost[id_root[k]] = k;
+    }
+
+    boost::mpi::broadcast(M_comm, &id_ghost[0], Mesh.numGlobalNodes()+1, 0);
+
+    // Correct the indices in the triangles
+    std::map<int, Nextsim::entities::GMSHPoint > nodes = Mesh.nodes();
     for (int k = 0; k < 3*Mesh.numTrianglesWithoutGhost(); k++)
     {
         if (indexTr[k] <= Mesh.numLocalNodesWithoutGhost())
@@ -289,144 +115,55 @@ Exporter::writeMesh(MPI_File& out, GmshMesh const& Mesh, std::vector<int>& rmap_
         }
         else // it is a ghost that belongs to another partition
         {
-            indexTr[k] = id_ghost[id_local_ghost[indexTr[k]-num_nodes-1]]+1;
+            indexTr[k] = id_ghost[nodes.find(indexTr[k])->second.id]+1;
         }
     }
 
-    // Correct the global indices with the root node ordering
-    // And split the indexTr array to use the orderField function
-    std::vector<int> node_correspondence(rmap_nodes.size());
-    for (int i = 0; i < rmap_nodes.size(); ++i) node_correspondence[rmap_nodes[i]] = i;
+    // Gather triangle indices
+    displs[0] = 0;
+    for (int k = 1; k < M_comm.size(); k++) displs[k] = displs[k-1] + size_elements[k-1];
 
-    int n_triangles = indexTr.size()/3;
-    std::vector<int> indexTr1(n_triangles);
-    std::vector<int> indexTr2(n_triangles);
-    std::vector<int> indexTr3(n_triangles);
-    for (int i = 0; i < n_triangles; i++)
-    {
-        indexTr1[i] = node_correspondence[indexTr[3*i]-1]+1;
-        indexTr2[i] = node_correspondence[indexTr[3*i+1]-1]+1;
-        indexTr3[i] = node_correspondence[indexTr[3*i+2]-1]+1;
-    }
-
-    std::vector<int> indexTr1_out(n_triangles);
-    std::vector<int> indexTr2_out(n_triangles);
-    std::vector<int> indexTr3_out(n_triangles);
-    orderField(indexTr1, indexTr1_out, rmap_elements, Mesh.comm(), n_triangles, 0);
-    orderField(indexTr2, indexTr2_out, rmap_elements, Mesh.comm(), n_triangles, 0);
-    orderField(indexTr3, indexTr3_out, rmap_elements, Mesh.comm(), n_triangles, 0);
-
-    std::vector<int> indexTr_out(3*n_triangles);
-    for (int i = 0; i < n_triangles; i++)
-    {
-        indexTr_out[3*i] = indexTr1_out[i];
-        indexTr_out[3*i+1] = indexTr2_out[i];
-        indexTr_out[3*i+2] = indexTr3_out[i];
-    }
-
-    // Write the mesh
-    this->writeMesh(out, coordX_out, coordY_out, id_out, indexTr_out, M_comm);
-
-}//writeMesh
-
-template<typename Type>
-void
-Exporter::writeMesh(MPI_File& out, std::vector<Type> const &xnod, std::vector<Type> const &ynod,
-                    std::vector<int> const &idnod, std::vector<int> const &elements, Communicator M_comm)
-{
-    std::string description;
-    MPI_Offset base_offset = 0;
-
-    std::vector<int> field_int = elements;
-    writeContainer(out, field_int, 0, M_comm, base_offset, "int");
-
-    int min_element = *std::min_element(field_int.begin(), field_int.end());
-    int max_element = *std::max_element(field_int.begin(), field_int.end());
-    int min_element_global, max_element_global, global_element_size;
-    boost::mpi::reduce(M_comm, min_element, min_element_global, boost::mpi::minimum<int>(), 0);
-    boost::mpi::reduce(M_comm, max_element, max_element_global, boost::mpi::maximum<int>(), 0);
-    boost::mpi::reduce(M_comm, int(field_int.size()), global_element_size, std::plus<int>(), 0);
+    ier = MPI_Gatherv(&indexTr[0], 3*Mesh.numTrianglesWithoutGhost(), MPI_INT, &indexTr_root[0], &size_elements[0], &displs[0], MPI_INT, 0, MPI_Comm(M_comm));
 
     if (M_comm.rank() == 0)
     {
-        description = (boost::format( "%1% %2% %3$g %4$g %5$g" )
-                       % "Elements"
-                       % "int"
-                       % global_element_size
-                       % min_element_global
-                       % max_element_global).str();
-        M_mrecord.push_back(description);
+        std::vector<double> coordX_out(Mesh.numGlobalNodes());
+        std::vector<double> coordY_out(Mesh.numGlobalNodes());
+        std::vector<int> indexTr_out(indexTr_root.size());
+        std::vector<int> id_out(Mesh.numGlobalNodes());
+        std::vector<int> node_correspondence(Mesh.numGlobalNodes());
+
+        std::vector<int> M_rmap_nodes = Mesh.mapNodes();
+        std::vector<int> M_rmap_elements = Mesh.mapElements();
+
+        // Reorder nodes to correspond to the node fields
+        for (int i = 0; i < Mesh.numGlobalNodes(); ++i)
+        {
+            int ri =  M_rmap_nodes[i];
+            node_correspondence[ri] = i;
+
+            coordX_out[i] = coordX_root[ri];
+            coordY_out[i] = coordY_root[ri];
+            id_out[i] = id_root[ri];
+        }
+
+        for (int i = 0; i < indexTr_root.size(); i++) indexTr_out[i] = node_correspondence[indexTr_root[i]-1]+1;
+
+        // Reorder the elements to correspond to the element fields
+        auto indexTr_out_cpy = indexTr_out;
+
+        for (int i = 0; i < indexTr_root.size(); i++)
+        {
+            int ri = M_rmap_elements[i/3];
+            indexTr_out[i] = indexTr_out_cpy[3*ri+i%3];
+        }
+
+        // Write the mesh
+        this->writeMesh(out, coordX_out, coordY_out, id_out, indexTr_out);
     }
 
-    field_int = idnod;
-    writeContainer(out, field_int, 0, M_comm, base_offset, "int");
-
-    int min_id = *std::min_element(field_int.begin(), field_int.end());
-    int max_id = *std::max_element(field_int.begin(), field_int.end());
-    int min_id_global, max_id_global, global_id_size;
-    boost::mpi::reduce(M_comm, min_id, min_id_global, boost::mpi::minimum<int>(), 0);
-    boost::mpi::reduce(M_comm, max_id, max_id_global, boost::mpi::maximum<int>(), 0);
-    boost::mpi::reduce(M_comm, int(field_int.size()), global_id_size, std::plus<int>(), 0);
-
-    if (M_comm.rank() == 0)
-    {
-        description = (boost::format( "%1% %2% %3$g %4$g %5$g" )
-                       % "id"
-                       % "int"
-                       % global_id_size
-                       % min_id_global
-                       % max_id_global).str();
-        M_mrecord.push_back(description);
-    }
-
-    std::string prec = "double";
-    if (sizeof(Type)==sizeof(float))
-        prec = "float";
-
-    auto field = xnod;
-    writeContainer(out, field, 0, M_comm, base_offset, prec);
-
-    int min_x = *std::min_element(field.begin(), field.end());
-    int max_x = *std::max_element(field.begin(), field.end());
-    int min_x_global, max_x_global, global_x_size;
-    boost::mpi::reduce(M_comm, min_x, min_x_global, boost::mpi::minimum<double>(), 0);
-    boost::mpi::reduce(M_comm, max_x, max_x_global, boost::mpi::maximum<double>(), 0);
-    boost::mpi::reduce(M_comm, int(field.size()), global_x_size, std::plus<int>(), 0);
-
-    if (M_comm.rank() == 0)
-    {
-        description = (boost::format( "%1% %2% %3$g %4$g %5$g" )
-                       % "Nodes_x"
-                       % prec
-                       % global_x_size
-                       %  min_x_global
-                       % max_x_global ).str();
-        M_mrecord.push_back(description);
-    }
-
-    field = ynod;
-    writeContainer(out, field, 0, M_comm, base_offset, prec);
-
-    int min_y = *std::min_element(field.begin(), field.end());
-    int max_y = *std::max_element(field.begin(), field.end());
-    int min_y_global, max_y_global, global_y_size;
-    boost::mpi::reduce(M_comm, min_y, min_y_global, boost::mpi::minimum<double>(), 0);
-    boost::mpi::reduce(M_comm, max_y, max_y_global, boost::mpi::maximum<double>(), 0);
-    boost::mpi::reduce(M_comm, int(field.size()), global_y_size, std::plus<int>(), 0);
-
-    if (M_comm.rank() == 0)
-    {
-        description = (boost::format( "%1% %2% %3$g %4$g %5$g" )
-                       % "Nodes_y"
-                       % prec
-                       % global_y_size
-                       % min_y_global
-                       % max_y_global ).str();
-        M_mrecord.push_back(description);
-    }
 }
 
-// writeMesh sequentially
 void
 Exporter::writeMesh(std::fstream& out, GmshMeshSeq const& Mesh)
 {
@@ -490,94 +227,6 @@ Exporter::writeMesh(std::fstream& out, std::vector<Type> const &xnod, std::vecto
     M_mrecord.push_back(description);
 }
 
-//writeField in parallel
-template<typename Type>
-void
-Exporter::writeField(MPI_File& out, std::vector<Type> const& field, std::string const& name, Communicator M_comm, 
-                     MPI_Offset& base_offset, std::vector<int>& rmap, int size_without_ghost, int num_nodes, int root)
-{
-    std::string description;
-    std::string precision;
-
-    if (((boost::any)field[0]).type() == typeid(int))
-        precision = "int";
-    else
-        precision = M_precision;
-
-    if (name == "Time") precision = "double";
-
-    MPI_Datatype mpi_type;
-    size_t elem_size = 0;
-    if (precision == "float")      { mpi_type = MPI_FLOAT;  elem_size = sizeof(float); }
-    else if (precision == "double"){ mpi_type = MPI_DOUBLE; elem_size = sizeof(double); }
-    else if (precision == "int")   { mpi_type = MPI_INT;    elem_size = sizeof(int); }
-
-    // For the fields written only by the root process
-    if (root)
-    {
-        if (M_comm.rank() == 0) 
-        {
-            int size = field.size();
-            MPI_File_write_at(out, base_offset, &size, 1, MPI_INT, MPI_STATUS_IGNORE);
-            base_offset += sizeof(size);
-            MPI_File_write_at(out, base_offset, field.data(), size, mpi_type, MPI_STATUS_IGNORE);
-            base_offset += size * elem_size;
-
-            description = (boost::format( "%1% %2% %3$g %4$g %5$g" )
-                       % name
-                       % precision
-                       % field.size()
-                       % ( (field.size() > 0) ? *std::min_element(field.begin(), field.end()) : 0 )
-                       % ( (field.size() > 0) ? *std::max_element(field.begin(), field.end()) : 0 ) ).str();
-
-            M_frecord.push_back(description);
-        }
-
-        boost::mpi::broadcast(M_comm, &base_offset, 1, 0);
-        return;
-    }
-
-    std::vector<Type> order_field;
-    int is_vector = 0;
-    if (field.size() == 2*num_nodes) // it is a vector node field
-    {
-        order_field.resize(2*size_without_ghost);
-        is_vector = 1;
-    }
-    else if (field.size() == num_nodes) // it is a scalar node field
-    {
-        order_field.resize(size_without_ghost);
-    }
-    else // it is an element field
-    {
-        order_field.resize(field.size());
-    }
-
-    orderField(field, order_field, rmap, M_comm, size_without_ghost, num_nodes);
-    writeContainer(out, order_field, is_vector, M_comm, base_offset, precision);
-
-    int min_element = *std::min_element(field.begin(), field.end());
-    int max_element = *std::max_element(field.begin(), field.end());
-    int min_element_global, max_element_global, global_element_size;
-    boost::mpi::reduce(M_comm, min_element, min_element_global, boost::mpi::minimum<int>(), 0);
-    boost::mpi::reduce(M_comm, max_element, max_element_global, boost::mpi::maximum<int>(), 0);
-    boost::mpi::reduce(M_comm, int(order_field.size()), global_element_size, std::plus<int>(), 0);
-
-    if (M_comm.rank() == 0)
-    {
-        description = (boost::format( "%1% %2% %3$g %4$g %5$g" )
-                       % name
-                       % precision
-                       % global_element_size
-                       % min_element_global
-                       % max_element_global).str();
-
-        M_frecord.push_back(description);
-    }
-
-}//writeField
-
-//writeField sequentially
 template<typename Type>
 void
 Exporter::writeField(std::fstream& out, std::vector<Type> const& field, std::string const& name)
@@ -600,10 +249,10 @@ Exporter::writeField(std::fstream& out, std::vector<Type> const& field, std::str
                    % name
                    % precision
                    % field.size()
-                   % ( (field.size() > 0) ? *std::min_element(field.begin(), field.end()) : 0 ) 
+                   % ( (field.size() > 0) ? *std::min_element(field.begin(), field.end()) : 0 )
                    % ( (field.size() > 0) ? *std::max_element(field.begin(), field.end()) : 0 ) ).str();
 
-    M_frecord.push_back(description);
+	M_frecord.push_back(description);
 }
 
 void
@@ -676,11 +325,6 @@ Exporter::loadFile(std::fstream &in, boost::unordered_map<std::string, std::vect
 
 template void Exporter::writeField<double>(std::fstream&, std::vector<double> const&, std::string const&);
 template void Exporter::writeField<int>(std::fstream&, std::vector<int> const&, std::string const&);
-
-template void Exporter::writeField(MPI_File& out, std::vector<double> const& field, std::string const& name, Communicator M_comm, 
-                                   MPI_Offset& base_offset, std::vector<int>& rmap, int size_without_ghost, int num_nodes, int root);
-template void Exporter::writeField(MPI_File& out, std::vector<int> const& field, std::string const& name, Communicator M_comm, 
-                                   MPI_Offset& base_offset, std::vector<int>& rmap, int size_without_ghost, int num_nodes, int root);
 
 template void Exporter::writeMesh<double>(std::fstream&, std::vector<double> const&, std::vector<double> const&,
         std::vector<int> const&,std::vector<int> const&);

--- a/model/Makefile
+++ b/model/Makefile
@@ -33,6 +33,7 @@ endif
 endif
 
 # add include paths
+CXXFLAGS += -I.
 CXXFLAGS += -I$(NEXTSIMDIR)/core/include
 CXXFLAGS += -I$(NEXTSIMDIR)/contrib/bamg/include
 CXXFLAGS += -I$(NEXTSIMDIR)/contrib/mapx/include
@@ -50,10 +51,9 @@ ifdef USE_AEROBULK
 endif
 
 # boost
-ifeq ($(BOOST_DIR),/usr)
-	CXXFLAGS += -I$(BOOST_INCDIR)/ -I.
-else
-	CXXFLAGS += -isystem $(BOOST_INCDIR)/ -I.
+# don't add /usr/include - it is already in  the default path and setting it with -isystem causes problems
+ifneq ($(BOOST_DIR),/usr)
+	CXXFLAGS += -isystem $(BOOST_INCDIR)
 endif
 
 # netcdf
@@ -68,12 +68,11 @@ ifdef USE_OASIS
 	LDFLAGS += -L$(NETCDF_FOR_DIR)/lib -lnetcdff
 endif
 
-ifeq ($(NETCDF_DIR),/usr)
-	#needed for maud: need -I/usr/include otherwise have problems with stdlib.h
-	CXXFLAGS += -I$(NETCDF_DIR)/include
-	CXXFLAGS += -I$(NETCDF_CXX_DIR)/include
-else
+# don't add /usr/include - it is already in  the default path and setting it with -isystem causes problems
+ifneq ($(NETCDF_DIR),/usr)
 	CXXFLAGS += -isystem $(NETCDF_DIR)/include
+endif
+ifneq ($(NETCDF_CXX_DIR),/usr)
 	CXXFLAGS += -isystem $(NETCDF_CXX_DIR)/include
 endif
 

--- a/model/drifters.cpp
+++ b/model/drifters.cpp
@@ -387,10 +387,10 @@ Drifters::addToRestart(Exporter &exporter, MPI_File& outbin, Communicator M_comm
     // write the fields to file
     std::vector<double> const t = {M_time_init};
     std::vector<int> unused;
-    exporter.writeField(outbin, M_i, "Drifter_ID_"        + M_tag, "int",  M_comm, base_offset, unused, 0, 0, 1);
-    exporter.writeField(outbin, M_X, "Drifter_x_"         + M_tag, "double", M_comm, base_offset, unused, 0, 0, 1);
-    exporter.writeField(outbin, M_Y, "Drifter_y_"         + M_tag, "double", M_comm, base_offset, unused, 0, 0, 1);
-    exporter.writeField(outbin, t,   "Drifter_time_init_" + M_tag, "double", M_comm, base_offset, unused, 0, 0, 1);
+    exporter.writeField(outbin, M_i, "Drifter_ID_"        + M_tag, M_comm, base_offset, unused, 0, 0, 1);
+    exporter.writeField(outbin, M_X, "Drifter_x_"         + M_tag, M_comm, base_offset, unused, 0, 0, 1);
+    exporter.writeField(outbin, M_Y, "Drifter_y_"         + M_tag, M_comm, base_offset, unused, 0, 0, 1);
+    exporter.writeField(outbin, t,   "Drifter_time_init_" + M_tag, M_comm, base_offset, unused, 0, 0, 1);
 }//addToRestart()
 
 

--- a/model/drifters.cpp
+++ b/model/drifters.cpp
@@ -377,20 +377,20 @@ Drifters::sortDrifterNumbers()
 //! Add drifter info to restart
 //! Called by FiniteElement::writeRestart()
 void
-Drifters::addToRestart(Exporter &exporter, MPI_File& outbin, Communicator M_comm, MPI_Offset& base_offset)
+Drifters::addToRestart(Exporter &exporter, std::fstream &outbin)
 {
     // Do nothing if we don't have to
-    int keep_going = M_i.size() + M_is_initialised;
-    boost::mpi::broadcast(M_comm, &keep_going, 1, 0);
-    if (!keep_going) return;
+    if (!M_is_initialised)
+        return;
+    if (M_i.size() == 0)
+        return;
 
     // write the fields to file
     std::vector<double> const t = {M_time_init};
-    std::vector<int> unused;
-    exporter.writeField(outbin, M_i, "Drifter_ID_"        + M_tag, M_comm, base_offset, unused, 0, 0, 1);
-    exporter.writeField(outbin, M_X, "Drifter_x_"         + M_tag, M_comm, base_offset, unused, 0, 0, 1);
-    exporter.writeField(outbin, M_Y, "Drifter_y_"         + M_tag, M_comm, base_offset, unused, 0, 0, 1);
-    exporter.writeField(outbin, t,   "Drifter_time_init_" + M_tag, M_comm, base_offset, unused, 0, 0, 1);
+    exporter.writeField(outbin, M_i, "Drifter_ID_"        + M_tag);
+    exporter.writeField(outbin, M_X, "Drifter_x_"         + M_tag);
+    exporter.writeField(outbin, M_Y, "Drifter_y_"         + M_tag);
+    exporter.writeField(outbin, t,   "Drifter_time_init_" + M_tag);
 }//addToRestart()
 
 

--- a/model/drifters.hpp
+++ b/model/drifters.hpp
@@ -164,7 +164,7 @@ public:
                 boost::unordered_map<std::string, std::vector<double>> & field_map_dbl
                 );
 
-        void addToRestart(Exporter &exporter, MPI_File &outbin, Communicator M_comm, MPI_Offset& base_offset);
+        void addToRestart(Exporter &exporter, std::fstream &outbin);
         bool isOutputTime(double const& current_time)
         {
             if(!M_is_initialised)

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -9607,22 +9607,6 @@ FiniteElement::writeRestart(std::string const& name_str)
     std::vector<double> M_UM_root;
     std::vector<double> M_UT_root;
 
-#if 1
-    if (M_rank == 0)
-    {
-        // write node IDs manually to check against restarts
-        std::string filename = (boost::format( "%1%/restart/node_ids_%2%.txt" )
-                    % vm["output.exporter_path"].as<std::string>()
-                    % name_str ).str();
-        std::ofstream out_file(filename);
-        if (!out_file)
-            throw std::runtime_error("Cannot write to file: " + filename);
-        for (int val : M_mesh_root.id())
-            out_file << val << "\n";
-        out_file.close();
-    }
-#endif
-
     int tmp_nb_var=0;
 
     if (M_rank == 0)
@@ -14321,18 +14305,6 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
 
             exporter.writeMesh(mesh_bin, output_mesh);
             mesh_bin.close();
-
-            {
-                // write node IDs manually to check against binary output
-                std::string filename = filenames[0] + ".txt";
-                std::ofstream out_file(filename);
-                if (!out_file)
-                    throw std::runtime_error("Cannot write to file: " + filename);
-                for (int val : M_mesh_root.id())
-                    out_file << val << "\n";
-                out_file.close();
-            }
-
 
             // mesh*.dat
             fileout = filenames[0]+".dat";

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -9593,8 +9593,7 @@ FiniteElement::writeRestart(std::string const& name_str)
     LOG(DEBUG) <<"M_prv_global_num_elements = "<< M_prv_global_num_elements <<"\n";
     LOG(DEBUG) <<"M_ndof                    = "<< M_ndof <<"\n";
 
-    Exporter exporter;
-    std::string const precision = "double";
+    Exporter exporter("double");
     std::string filename;
 
     // === Start with the mesh ===
@@ -9666,14 +9665,14 @@ FiniteElement::writeRestart(std::string const& name_str)
     misc_int[2] = mesh_adapt_step;
     misc_int[3] = M_nb_regrid;
 
-    exporter.writeField(outbin, misc_int, "Misc_int", "int", M_comm, base_offset,
+    exporter.writeField(outbin, misc_int, "Misc_int", M_comm, base_offset,
                         rmap_nodes, M_local_ndof, M_num_nodes, 1);
-    exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags", "int", M_comm, base_offset,
+    exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags", M_comm, base_offset,
                         rmap_nodes, M_local_ndof, M_num_nodes, 1);
 
-    std::vector<double> timevec(1);// time always written as double
+    std::vector<double> timevec(1);
     timevec[0] = M_current_time;
-    exporter.writeField(outbin, timevec, "Time", "double", M_comm, base_offset,
+    exporter.writeField(outbin, timevec, "Time", M_comm, base_offset,
                         rmap_nodes, M_local_ndof, M_num_nodes, 1);
 
     // loop over the elemental variables
@@ -9686,13 +9685,13 @@ FiniteElement::writeRestart(std::string const& name_str)
         {
             tmp[i] = (*ptr)[i];
         }
-        exporter.writeField(outbin, tmp, M_restart_names_elt[j], precision, M_comm, base_offset,
+        exporter.writeField(outbin, tmp, M_restart_names_elt[j], M_comm, base_offset, 
                             rmap_elements, M_local_nelements, 0, 0);
     }
 
-    exporter.writeField(outbin, M_VT, "M_VT", precision, M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-    exporter.writeField(outbin, M_UM, "M_UM", precision, M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-    exporter.writeField(outbin, M_UT, "M_UT", precision, M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
+    exporter.writeField(outbin, M_VT, "M_VT", M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
+    exporter.writeField(outbin, M_UM, "M_UM", M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
+    exporter.writeField(outbin, M_UT, "M_UT", M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
 
     // Add the drifters if they are initialised
     for (auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
@@ -9705,7 +9704,7 @@ FiniteElement::writeRestart(std::string const& name_str)
         for ( int i=0; i<M_mesh_root.numNodes(); ++i )
             PreviousNumbering[i] = bamgmesh_root->PreviousNumbering[i];
 
-    exporter.writeField(outbin, PreviousNumbering, "PreviousNumbering", precision, M_comm, base_offset,
+    exporter.writeField(outbin, PreviousNumbering, "PreviousNumbering", M_comm, base_offset,
                         rmap_nodes, M_local_ndof, M_num_nodes, 1);
 
     MPI_File_close(&outbin);
@@ -9732,7 +9731,7 @@ FiniteElement::writeRestart(std::string const& name_str)
 void
 FiniteElement::readRestart(std::string const& name_str)
 {
-    Exporter exp_field, exp_mesh;
+    Exporter exp_field("double"), exp_mesh("double");
     std::string filename;
     boost::unordered_map<std::string, std::vector<int>>    field_map_int;
     boost::unordered_map<std::string, std::vector<double>> field_map_dbl;
@@ -14227,7 +14226,7 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
         boost::mpi::broadcast(M_comm, &rmap_elements[0], size_elements, 0);
     }
 
-    Exporter exporter;
+    Exporter exporter(vm["output.exporter_precision"].as<std::string>());
     std::string fileout;
 
     if (export_mesh)
@@ -14270,7 +14269,6 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
 
     if (export_fields)
     {
-        std::string const precision = vm["output.exporter_precision"].as<std::string>();
         MPI_Offset base_offset = 0;
 
         fileout = filenames[1]+".bin";
@@ -14281,27 +14279,27 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
                       MPI_INFO_NULL, &outbin);
 
         // Nodes
-        std::vector<double> timevec = {M_current_time};// time always written as double
-        exporter.writeField(outbin, timevec, "Time", "double", M_comm, base_offset,
+        std::vector<double> timevec = {M_current_time};
+        exporter.writeField(outbin, timevec, "Time", M_comm, base_offset, 
                             rmap_nodes, M_local_ndof, M_num_nodes, 1);
 
         //manually export some vectors defined on the nodes
         std::vector<std::string> names = vm["output.variables"].as<std::vector<std::string>>();
         if ( std::find(names.begin(), names.end(), "M_VT") != names.end() )
-            exporter.writeField(outbin, M_VT, "M_VT", precision, M_comm, base_offset,
+            exporter.writeField(outbin, M_VT, "M_VT", M_comm, base_offset, 
                                 rmap_nodes, M_local_ndof, M_num_nodes, 0);
 #if defined (OASIS)
         if (M_couple_waves && M_recv_wave_stress)
-            exporter.writeField(outbin, M_tau_wi.getVector(), "M_tau_wi", precision, M_comm,
+            exporter.writeField(outbin, M_tau_wi.getVector(), "M_tau_wi", M_comm, 
                                 base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
 #endif
         if (vm["output.save_forcing_fields"].as<bool>())
         {
-            exporter.writeField(outbin, M_wind.getVector(), "M_wind", precision, M_comm,
+            exporter.writeField(outbin, M_wind.getVector(), "M_wind", M_comm, 
                                 base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-            exporter.writeField(outbin, M_ocean.getVector(), "M_ocean", precision, M_comm,
+            exporter.writeField(outbin, M_ocean.getVector(), "M_ocean", M_comm, 
                                 base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-            exporter.writeField(outbin, M_ssh.getVector(), "M_ssh", precision, M_comm,
+            exporter.writeField(outbin, M_ssh.getVector(), "M_ssh", M_comm, 
                                 base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
         }
 
@@ -14316,7 +14314,7 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
             {       
                 elt_values_local[i] = (*ptr)[i];
             }
-            exporter.writeField(outbin, elt_values_local, names_elements[j], precision, M_comm,
+            exporter.writeField(outbin, elt_values_local, names_elements[j], M_comm, 
                                 base_offset, rmap_elements, M_local_nelements, unused_int, 0);
         }
         if(vm["output.save_forcing_fields"].as<bool>())
@@ -14330,7 +14328,7 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
                 {
                 	elt_values_local[i] = (*ptr)[i];
                 }
-                exporter.writeField(outbin, elt_values_local, names_elements[j+M_export_variables_elt.size()], precision,
+                exporter.writeField(outbin, elt_values_local, names_elements[j+M_export_variables_elt.size()], 
                                     M_comm, base_offset, rmap_elements, M_local_nelements, unused_int, 0);
         	}
         }

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -9671,30 +9671,30 @@ FiniteElement::writeRestart(std::string const& name_str)
                     % directory
                     % name_str ).str();
 
-        std::fstream meshbin(filename, std::ios::binary | std::ios::out | std::ios::trunc);
-        if ( ! meshbin.good() )
+        std::fstream mesh_bin(filename, std::ios::binary | std::ios::out | std::ios::trunc);
+        if ( ! mesh_bin.good() )
             throw std::runtime_error("Cannot write to file: " + filename);
-        exporter.writeMesh(meshbin, M_mesh_root);
-        meshbin.close();
+        exporter.writeMesh(mesh_bin, M_mesh_root);
+        mesh_bin.close();
 
         // Then the record
         filename = (boost::format( "%1%/mesh_%2%.dat" )
                     % directory
                     % name_str ).str();
 
-        std::fstream meshrecord(filename, std::ios::out | std::ios::trunc);
-        if ( ! meshrecord.good() )
+        std::fstream mesh_dat(filename, std::ios::out | std::ios::trunc);
+        if ( ! mesh_dat.good() )
             throw std::runtime_error("Cannot write to file: " + filename);
-        exporter.writeRecord(meshrecord,"mesh");
-        meshrecord.close();
+        exporter.writeRecord(mesh_dat,"mesh");
+        mesh_dat.close();
 
         // === Write the prognostic variables ===
         // First the data
         filename = (boost::format( "%1%/field_%2%.bin" )
                     % directory
                     % name_str ).str();
-        std::fstream outbin(filename, std::ios::binary | std::ios::out | std::ios::trunc );
-        if ( ! outbin.good() )
+        std::fstream field_bin(filename, std::ios::binary | std::ios::out | std::ios::trunc );
+        if ( ! field_bin.good() )
             throw std::runtime_error("Cannot write to file: " + filename);
 
         std::vector<int> misc_int(4);
@@ -9703,13 +9703,13 @@ FiniteElement::writeRestart(std::string const& name_str)
         misc_int[2] = mesh_adapt_step;
         misc_int[3] = M_nb_regrid;
 
-        exporter.writeField(outbin, misc_int, "Misc_int");
-        exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags");
+        exporter.writeField(field_bin, misc_int, "Misc_int");
+        exporter.writeField(field_bin, M_dirichlet_flags_root, "M_dirichlet_flags");
 
 
         std::vector<double> timevec(1);
         timevec[0] = M_current_time;
-        exporter.writeField(outbin, timevec, "Time");
+        exporter.writeField(field_bin, timevec, "Time");
 
         // loop over the elemental variables that have been
         // gathered to elt_values_root
@@ -9722,37 +9722,37 @@ FiniteElement::writeRestart(std::string const& name_str)
                 int ri = M_rmap_elements[i];
                 tmp[i] = elt_values_root[nb_var_element*ri+j];
             }
-            exporter.writeField(outbin, tmp, M_restart_names_elt[j]);
+            exporter.writeField(field_bin, tmp, M_restart_names_elt[j]);
         }
 
-        exporter.writeField(outbin, M_VT_root, "M_VT");
-        exporter.writeField(outbin, M_UM_root, "M_UM");
-        exporter.writeField(outbin, M_UT_root, "M_UT");
+        exporter.writeField(field_bin, M_VT_root, "M_VT");
+        exporter.writeField(field_bin, M_UM_root, "M_UM");
+        exporter.writeField(field_bin, M_UT_root, "M_UT");
 
         // Add the drifters if they are initialised
         for (auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
-            it->addToRestart(exporter, outbin);
+            it->addToRestart(exporter, field_bin);
 
         // Add the previous numbering to the restart file
         // - used in adaptMesh (updateNodeIds)
         std::vector<double> PreviousNumbering(M_mesh_root.numNodes());
         for ( int i=0; i<M_mesh_root.numNodes(); ++i )
             PreviousNumbering[i] = bamgmesh_root->PreviousNumbering[i];
-        exporter.writeField(outbin, PreviousNumbering, "PreviousNumbering");
+        exporter.writeField(field_bin, PreviousNumbering, "PreviousNumbering");
 
-        outbin.close();
+        field_bin.close();
 
         // Then the record
         filename = (boost::format( "%1%/field_%2%.dat" )
                     % directory
                     % name_str ).str();
 
-        std::fstream outrecord(filename, std::ios::out | std::ios::trunc);
-        if ( ! outrecord.good() )
+        std::fstream field_dat(filename, std::ios::out | std::ios::trunc);
+        if ( ! field_dat.good() )
             throw std::runtime_error("Cannot write to file: " + filename);
 
-        exporter.writeRecord(outrecord);
-        outrecord.close();
+        exporter.writeRecord(field_dat);
+        field_dat.close();
     }
 }//writeRestart
 
@@ -14290,70 +14290,63 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
 
         if (export_mesh)
         {
+            // mesh*.bin
             fileout = filenames[0]+".bin";
             LOG(VERBOSE) <<"MESH BINARY: Exporter Filename= "<< fileout <<"\n";
 
-            if(apply_displacement)
-            {
-                // move the mesh for the export
-                M_mesh_root.move(M_UM_root,1.);
-            }
+            // Make a copy of the mesh to avoid introduction of random modifications
+            // in the next timesteps introduced by two mesh moves (1 and -1) on M_mesh_root
+            auto output_mesh = M_mesh_root;
+            if(apply_displacement) output_mesh.move(M_UM_root,1.);
 
-            std::fstream meshbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
-            if ( !meshbin.good() )
+            std::fstream mesh_bin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
+            if ( !mesh_bin.good() )
                 throw std::runtime_error("Cannot write to file: " + fileout);
 
-            exporter.writeMesh(meshbin, M_mesh_root);
-            meshbin.close();
+            exporter.writeMesh(mesh_bin, output_mesh);
+            mesh_bin.close();
 
-            if(apply_displacement)
-            {
-                // move it back after the export
-                M_mesh_root.move(M_UM_root,-1.);
-            }
 
+            // mesh*.dat
             fileout = filenames[0]+".dat";
-
             LOG(VERBOSE) <<"RECORD MESH: Exporter Filename= "<< fileout <<"\n";
 
-            std::fstream outrecord(fileout, std::ios::out | std::ios::trunc);
-            if ( !outrecord.good() )
+            std::fstream mesh_dat(fileout, std::ios::out | std::ios::trunc);
+            if ( !mesh_dat.good() )
                 throw std::runtime_error("Cannot write to file: " + fileout);
 
-            exporter.writeRecord(outrecord,"mesh");
-            outrecord.close();
+            exporter.writeRecord(mesh_dat,"mesh");
+            mesh_dat.close();
         }
 
         if (export_fields)
         {
+            // field*.bin
             fileout = filenames[1]+".bin";
             LOG(VERBOSE) <<"BINARY: Exporter Filename= "<< fileout <<"\n";
 
-            std::fstream outbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
-            if ( !outbin.good() )
+            std::fstream field_bin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
+            if ( !field_bin.good() )
                 throw std::runtime_error("Cannot write to file: " + fileout);
 
             std::vector<double> timevec = {M_current_time};
             std::vector<int> regridvec = {M_nb_regrid};
 
-            exporter.writeField(outbin, timevec, "Time");
-            // exporter.writeField(outbin, regridvec, "M_nb_regrid");
-            // exporter.writeField(outbin, M_surface_root, "Element_area");
-            // exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags");
+            exporter.writeField(field_bin, timevec, "Time");
 
             //manually export some vectors defined on the nodes
             std::vector<std::string> names = vm["output.variables"].as<std::vector<std::string>>();
             if ( std::find(names.begin(), names.end(), "M_VT") != names.end() )
-                exporter.writeField(outbin, M_VT_root, "M_VT");
+                exporter.writeField(field_bin, M_VT_root, "M_VT");
 #if defined (OASIS)
             if (M_couple_waves && M_recv_wave_stress)
-                exporter.writeField(outbin, M_tau_wi_root, "M_tau_wi");
+                exporter.writeField(field_bin, M_tau_wi_root, "M_tau_wi");
 #endif
             if (vm["output.save_forcing_fields"].as<bool>())
             {
-                exporter.writeField(outbin, M_wind_root, "M_wind");
-                exporter.writeField(outbin, M_ocean_root, "M_ocean");
-                exporter.writeField(outbin, M_ssh_root, "M_ssh");
+                exporter.writeField(field_bin, M_wind_root, "M_wind");
+                exporter.writeField(field_bin, M_ocean_root, "M_ocean");
+                exporter.writeField(field_bin, M_ssh_root, "M_ssh");
             }
 
 
@@ -14368,36 +14361,22 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
                     int ri = M_rmap_elements[i];
                     tmp[i] = elt_values_root[nb_var_element*ri+j];
                 }
-                exporter.writeField(outbin, tmp, names_elements[j]);
+                exporter.writeField(field_bin, tmp, names_elements[j]);
 
             }
 
-            outbin.close();
+            field_bin.close();
 
+            // field*.dat
             fileout = filenames[1]+".dat";
             LOG(VERBOSE) <<"RECORD FIELD: Exporter Filename= "<< fileout <<"\n";
 
-            std::fstream outrecord(fileout, std::ios::out | std::ios::trunc);
-            if ( !outrecord.good() )
+            std::fstream field_dat(fileout, std::ios::out | std::ios::trunc);
+            if ( !field_dat.good() )
                 throw std::runtime_error("Cannot write to file: " + fileout);
 
-            exporter.writeRecord(outrecord);
-            outrecord.close();
-        }
-
-        outbin.close();
-
-        if (M_rank == 0)
-        {
-            fileout = filenames[1]+".dat";
-            LOG(VERBOSE) <<"RECORD FIELD: Exporter Filename= "<< fileout <<"\n";
-    
-            std::fstream outrecord(fileout, std::ios::out | std::ios::trunc);
-            if ( !outrecord.good() )
-                throw std::runtime_error("Cannot write to file: " + fileout);
-    
-            exporter.writeRecord(outrecord);
-            outrecord.close();
+            exporter.writeRecord(field_dat);
+            field_dat.close();
         }
     }
 

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -14322,6 +14322,17 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
             exporter.writeMesh(mesh_bin, output_mesh);
             mesh_bin.close();
 
+            {
+                // write node IDs manually to check against binary output
+                std::string filename = filenames[0] + ".txt";
+                std::ofstream out_file(filename);
+                if (!out_file)
+                    throw std::runtime_error("Cannot write to file: " + filename);
+                for (int val : M_mesh_root.id())
+                    out_file << val << "\n";
+                out_file.close();
+            }
+
 
             // mesh*.dat
             fileout = filenames[0]+".dat";

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -9593,6 +9593,65 @@ FiniteElement::writeRestart(std::string const& name_str)
     LOG(DEBUG) <<"M_prv_global_num_elements = "<< M_prv_global_num_elements <<"\n";
     LOG(DEBUG) <<"M_ndof                    = "<< M_ndof <<"\n";
 
+    // get names of the variables in the restart file,
+    // and set pointers to the data (pointers to the corresponding vectors)
+    // NB needs to be done on all processors
+    std::vector<double> elt_values_root;
+    this->gatherFieldsElementIO(elt_values_root, M_prognostic_variables_elt);
+
+    // fields defined on mesh nodes
+    std::vector<double> interp_in_nodes;
+    this->gatherFieldsNode(interp_in_nodes, M_rmap_nodes, M_sizes_nodes);
+
+    std::vector<double> M_VT_root;
+    std::vector<double> M_UM_root;
+    std::vector<double> M_UT_root;
+
+    int tmp_nb_var=0;
+
+    if (M_rank == 0)
+    {
+        M_VT_root.resize(2*M_ndof);
+        M_UM_root.resize(2*M_ndof);
+        M_UT_root.resize(2*M_ndof);
+
+        for (int i=0; i<M_ndof; ++i)
+        {
+            tmp_nb_var = 0;
+
+            // VT_X
+            M_VT_root[i] = interp_in_nodes[M_nb_var_node*i+tmp_nb_var];
+            tmp_nb_var++;
+
+            // VT_Y
+            M_VT_root[i+M_ndof] = interp_in_nodes[M_nb_var_node*i+tmp_nb_var];
+            tmp_nb_var++;
+
+            // UM_X
+            M_UM_root[i] = interp_in_nodes[M_nb_var_node*i+tmp_nb_var];
+            tmp_nb_var++;
+
+            // UM_Y
+            M_UM_root[i+M_ndof] = interp_in_nodes[M_nb_var_node*i+tmp_nb_var];
+            tmp_nb_var++;
+
+            // UT_X
+            M_UT_root[i] = interp_in_nodes[M_nb_var_node*i+tmp_nb_var];
+            tmp_nb_var++;
+
+            // UT_Y
+            M_UT_root[i+M_ndof] = interp_in_nodes[M_nb_var_node*i+tmp_nb_var];
+            tmp_nb_var++;
+
+            if(tmp_nb_var>M_nb_var_node)
+            {
+                throw std::logic_error("tmp_nb_var not equal to nb_var");
+            }
+        }
+    }
+
+    M_comm.barrier();
+
     Exporter exporter("double");
     std::string filename;
 
@@ -9610,29 +9669,11 @@ FiniteElement::writeRestart(std::string const& name_str)
                 % directory
                 % name_str ).str();
 
-    // Write the file in parallel
-    MPI_File meshbin;
-    MPI_File_open(MPI_Comm(M_comm), filename.c_str(), MPI_MODE_CREATE | MPI_MODE_WRONLY,
-                  MPI_INFO_NULL, &meshbin);
-
-    // Write the mesh and close the file
-    std::vector<int> rmap_nodes, rmap_elements;
-    int size_nodes = M_rmap_nodes.size();
-    boost::mpi::broadcast(M_comm, &size_nodes, 1, 0);
-    int size_elements = M_rmap_elements.size();
-    boost::mpi::broadcast(M_comm, &size_elements, 1, 0);
-    rmap_nodes.resize(size_nodes);
-    rmap_elements.resize(size_elements);
-    if (M_rank == 0)
-    {
-        rmap_nodes = M_rmap_nodes;
-        rmap_elements = M_rmap_elements;
-    }
-    boost::mpi::broadcast(M_comm, &rmap_nodes[0], size_nodes, 0);
-    boost::mpi::broadcast(M_comm, &rmap_elements[0], size_elements, 0);
-
-    exporter.writeMesh(meshbin, M_mesh, rmap_nodes, rmap_elements);
-    MPI_File_close(&meshbin);
+    std::fstream meshbin(filename, std::ios::binary | std::ios::out | std::ios::trunc);
+    if ( ! meshbin.good() )
+        throw std::runtime_error("Cannot write to file: " + filename);
+    exporter.writeMesh(meshbin, M_mesh);
+    meshbin.close();
 
     if (M_rank == 0) 
     {
@@ -9646,71 +9687,61 @@ FiniteElement::writeRestart(std::string const& name_str)
             throw std::runtime_error("Cannot write to file: " + filename);
         exporter.writeRecord(meshrecord,"mesh");
         meshrecord.close();
-    }
 
-    // === Write the prognostic variables ===
-    // First the data
-    filename = (boost::format( "%1%/field_%2%.bin" )
-                % directory
-                % name_str ).str();
+        // === Write the prognostic variables ===
+        // First the data
+        filename = (boost::format( "%1%/field_%2%.bin" )
+                    % directory
+                    % name_str ).str();
+        std::fstream outbin(filename, std::ios::binary | std::ios::out | std::ios::trunc );
+        if ( ! outbin.good() )
+            throw std::runtime_error("Cannot write to file: " + filename);
 
-    MPI_Offset base_offset = 0;
-    MPI_File outbin;
-    MPI_File_open(MPI_Comm(M_comm), filename.c_str(), MPI_MODE_CREATE | MPI_MODE_WRONLY,
-                  MPI_INFO_NULL, &outbin);
+        std::vector<int> misc_int(4);
+        misc_int[0] = pcpt;
+        misc_int[1] = M_flag_fix;
+        misc_int[2] = mesh_adapt_step;
+        misc_int[3] = M_nb_regrid;
 
-    std::vector<int> misc_int(4);
-    misc_int[0] = pcpt;
-    misc_int[1] = M_flag_fix;
-    misc_int[2] = mesh_adapt_step;
-    misc_int[3] = M_nb_regrid;
+        exporter.writeField(outbin, misc_int, "Misc_int");
+        exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags");
 
-    exporter.writeField(outbin, misc_int, "Misc_int", M_comm, base_offset,
-                        rmap_nodes, M_local_ndof, M_num_nodes, 1);
-    exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags", M_comm, base_offset,
-                        rmap_nodes, M_local_ndof, M_num_nodes, 1);
 
-    std::vector<double> timevec(1);
-    timevec[0] = M_current_time;
-    exporter.writeField(outbin, timevec, "Time", M_comm, base_offset,
-                        rmap_nodes, M_local_ndof, M_num_nodes, 1);
+        std::vector<double> timevec(1);
+        timevec[0] = M_current_time;
+        exporter.writeField(outbin, timevec, "Time");
 
-    // loop over the elemental variables
-    int const nb_var_element = M_restart_names_elt.size();
-    for(int j = 0; j < nb_var_element; j++)
-    {
-        auto ptr = M_prognostic_variables_elt[j];
-        std::vector<double> tmp(M_local_nelements);
-        for (int i = 0; i < M_local_nelements; ++i)
+        // loop over the elemental variables that have been
+        // gathered to elt_values_root
+        int const nb_var_element = M_restart_names_elt.size();
+        for(int j=0; j<nb_var_element; j++)
         {
-            tmp[i] = (*ptr)[i];
+            std::vector<double> tmp(M_mesh_root.numTriangles());
+            for (int i=0; i<M_mesh_root.numTriangles(); ++i)
+            {
+                int ri = M_rmap_elements[i];
+                tmp[i] = elt_values_root[nb_var_element*ri+j];
+            }
+            exporter.writeField(outbin, tmp, M_restart_names_elt[j]);
         }
-        exporter.writeField(outbin, tmp, M_restart_names_elt[j], M_comm, base_offset, 
-                            rmap_elements, M_local_nelements, 0, 0);
-    }
 
-    exporter.writeField(outbin, M_VT, "M_VT", M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-    exporter.writeField(outbin, M_UM, "M_UM", M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-    exporter.writeField(outbin, M_UT, "M_UT", M_comm, base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
+        exporter.writeField(outbin, M_VT_root, "M_VT");
+        exporter.writeField(outbin, M_UM_root, "M_UM");
+        exporter.writeField(outbin, M_UT_root, "M_UT");
 
-    // Add the drifters if they are initialised
-    for (auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
-        it->addToRestart(exporter, outbin, M_comm, base_offset);
+        // Add the drifters if they are initialised
+        for (auto it=M_drifters.begin(); it!=M_drifters.end(); it++)
+            it->addToRestart(exporter, outbin);
 
-    // Add the previous numbering to the restart file
-    // - used in adaptMesh (updateNodeIds)
-    std::vector<double> PreviousNumbering(M_mesh_root.numNodes());
-    if (M_rank == 0)
+        // Add the previous numbering to the restart file
+        // - used in adaptMesh (updateNodeIds)
+        std::vector<double> PreviousNumbering(M_mesh_root.numNodes());
         for ( int i=0; i<M_mesh_root.numNodes(); ++i )
             PreviousNumbering[i] = bamgmesh_root->PreviousNumbering[i];
+        exporter.writeField(outbin, PreviousNumbering, "PreviousNumbering");
 
-    exporter.writeField(outbin, PreviousNumbering, "PreviousNumbering", M_comm, base_offset,
-                        rmap_nodes, M_local_ndof, M_num_nodes, 1);
+        outbin.close();
 
-    MPI_File_close(&outbin);
-
-    if (M_rank == 0)
-    {
         // Then the record
         filename = (boost::format( "%1%/field_%2%.dat" )
                     % directory
@@ -14207,24 +14238,44 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
     M_prv_global_num_nodes = M_mesh.numGlobalNodes();
     M_prv_global_num_elements = M_mesh.numGlobalElements();
 
-    // Need of the rmaps on each partition
-    std::vector<int> rmap_nodes, rmap_elements;
-    if (export_mesh || export_fields)
+    // get names of the variables in the output file,
+    // and set pointers to the data (pointers to the corresponding vectors)
+    // NB needs to be done on all processors
+    auto names_elements = M_export_names_elt;
+    std::vector<ExternalData*> ext_data_elements;
+    std::vector<double> elt_values_root;
+    std::vector<double> M_VT_root;
+#if defined (OASIS)
+    std::vector<double> M_tau_wi_root;
+#endif
+    std::vector<double> M_wind_root;
+    std::vector<double> M_ocean_root;
+    std::vector<double> M_ssh_root;
+    if(export_fields)
     {
-        int size_nodes = M_rmap_nodes.size();
-        boost::mpi::broadcast(M_comm, &size_nodes, 1, 0);
-        int size_elements = M_rmap_elements.size();
-        boost::mpi::broadcast(M_comm, &size_elements, 1, 0);
-        rmap_nodes.resize(size_nodes);
-        rmap_elements.resize(size_elements);
-        if (M_rank == 0)
+        if(vm["output.save_forcing_fields"].as<bool>())
         {
-            rmap_nodes = M_rmap_nodes;
-            rmap_elements = M_rmap_elements;
+            ext_data_elements = M_external_data_elements;
+            for(auto name : M_external_data_elements_names)
+                names_elements.push_back(name);
         }
-        boost::mpi::broadcast(M_comm, &rmap_nodes[0], size_nodes, 0);
-        boost::mpi::broadcast(M_comm, &rmap_elements[0], size_elements, 0);
+        this->gatherFieldsElementIO(elt_values_root, M_export_variables_elt, ext_data_elements);
+
+        // manually export some vectors defined on the nodes
+        this->gatherNodalField(M_VT, M_VT_root);
+#if defined (OASIS)
+        if (M_couple_waves && M_recv_wave_stress)
+            this->gatherNodalField(M_tau_wi.getVector(), M_tau_wi_root);
+#endif
+        if (vm["output.save_forcing_fields"].as<bool>())
+        {
+            this->gatherNodalField(M_wind.getVector(), M_wind_root);
+            this->gatherNodalField(M_ocean.getVector(), M_ocean_root);
+            this->gatherNodalField(M_ssh.getVector(), M_ssh_root);
+        }
+        this->gatherNodalField(M_wind.getVector(),M_wind_root);
     }
+    M_comm.barrier();
 
     Exporter exporter(vm["output.exporter_precision"].as<std::string>());
     std::string fileout;
@@ -14242,16 +14293,13 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
         // move the mesh for the export
         if(apply_displacement) M_mesh_cpy.move(M_UM,1.);
 
-        // Write the file in parallel
-        MPI_File meshbin;
-        MPI_File_open(MPI_Comm(M_comm), fileout.c_str(), MPI_MODE_CREATE | MPI_MODE_WRONLY, 
-                      MPI_INFO_NULL, &meshbin);
+        std::fstream meshbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
+        if ( !meshbin.good() )
+            throw std::runtime_error("Cannot write to file: " + fileout);
 
-        // Write the mesh and close the file
-        exporter.writeMesh(meshbin, M_mesh_cpy, rmap_nodes, rmap_elements);
-        MPI_File_close(&meshbin);
+        exporter.writeMesh(meshbin, M_mesh_cpy);
+        meshbin.close();
 
-        // Write the ascii file sequentially
         if (M_rank == 0)
         {
             fileout = filenames[0]+".dat";
@@ -14267,73 +14315,55 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
         }
     }
 
-    if (export_fields)
+    if (export_fields && M_rank == 0)
     {
-        MPI_Offset base_offset = 0;
-
         fileout = filenames[1]+".bin";
         LOG(VERBOSE) <<"BINARY: Exporter Filename= "<< fileout <<"\n";
 
-        MPI_File outbin;
-        MPI_File_open(MPI_Comm(M_comm), fileout.c_str(), MPI_MODE_CREATE | MPI_MODE_WRONLY, 
-                      MPI_INFO_NULL, &outbin);
+        std::fstream outbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
+        if ( !outbin.good() )
+            throw std::runtime_error("Cannot write to file: " + fileout);
 
-        // Nodes
         std::vector<double> timevec = {M_current_time};
-        exporter.writeField(outbin, timevec, "Time", M_comm, base_offset, 
-                            rmap_nodes, M_local_ndof, M_num_nodes, 1);
+        std::vector<int> regridvec = {M_nb_regrid};
+
+        exporter.writeField(outbin, timevec, "Time");
+        // exporter.writeField(outbin, regridvec, "M_nb_regrid");
+        // exporter.writeField(outbin, M_surface_root, "Element_area");
+        // exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags");
 
         //manually export some vectors defined on the nodes
         std::vector<std::string> names = vm["output.variables"].as<std::vector<std::string>>();
         if ( std::find(names.begin(), names.end(), "M_VT") != names.end() )
-            exporter.writeField(outbin, M_VT, "M_VT", M_comm, base_offset, 
-                                rmap_nodes, M_local_ndof, M_num_nodes, 0);
+            exporter.writeField(outbin, M_VT_root, "M_VT");
 #if defined (OASIS)
         if (M_couple_waves && M_recv_wave_stress)
-            exporter.writeField(outbin, M_tau_wi.getVector(), "M_tau_wi", M_comm, 
-                                base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
+            exporter.writeField(outbin, M_tau_wi_root, "M_tau_wi");
 #endif
         if (vm["output.save_forcing_fields"].as<bool>())
         {
-            exporter.writeField(outbin, M_wind.getVector(), "M_wind", M_comm, 
-                                base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-            exporter.writeField(outbin, M_ocean.getVector(), "M_ocean", M_comm, 
-                                base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
-            exporter.writeField(outbin, M_ssh.getVector(), "M_ssh", M_comm, 
-                                base_offset, rmap_nodes, M_local_ndof, M_num_nodes, 0);
+            exporter.writeField(outbin, M_wind_root, "M_wind");
+            exporter.writeField(outbin, M_ocean_root, "M_ocean");
+            exporter.writeField(outbin, M_ssh_root, "M_ssh");
         }
 
-        // Elements
-        int unused_int = 0;
-        auto names_elements = M_export_names_elt;
-        std::vector<double> elt_values_local(M_local_nelements);
-        for(int j = 0; j < M_export_variables_elt.size(); j++)
+
+        // loop over the elemental variables that have been
+        // gathered to elt_values_root
+        int const nb_var_element = names_elements.size();
+        for(int j=0; j<nb_var_element; j++)
         {
-            auto ptr = M_export_variables_elt[j];
-            for (int i = 0; i < M_local_nelements; ++i)
-            {       
-                elt_values_local[i] = (*ptr)[i];
+            std::vector<double> tmp(M_mesh_root.numTriangles());
+            for (int i=0; i<M_mesh_root.numTriangles(); ++i)
+            {
+                int ri = M_rmap_elements[i];
+                tmp[i] = elt_values_root[nb_var_element*ri+j];
             }
-            exporter.writeField(outbin, elt_values_local, names_elements[j], M_comm, 
-                                base_offset, rmap_elements, M_local_nelements, unused_int, 0);
-        }
-        if(vm["output.save_forcing_fields"].as<bool>())
-        {
-            for(auto name : M_external_data_elements_names) names_elements.push_back(name);
+            exporter.writeField(outbin, tmp, names_elements[j]);
 
-        	for(int j = 0; j < M_external_data_elements.size(); j++)
-        	{
-        	    auto ptr = M_external_data_elements[j];
-        	    for (int i = 0; i<M_local_nelements; ++i)
-                {
-                	elt_values_local[i] = (*ptr)[i];
-                }
-                exporter.writeField(outbin, elt_values_local, names_elements[j+M_export_variables_elt.size()], 
-                                    M_comm, base_offset, rmap_elements, M_local_nelements, unused_int, 0);
-        	}
         }
 
-        MPI_File_close(&outbin);
+        outbin.close();
 
         if (M_rank == 0)
         {

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -9652,31 +9652,31 @@ FiniteElement::writeRestart(std::string const& name_str)
 
     M_comm.barrier();
 
-    Exporter exporter("double");
-    std::string filename;
-
-    // === Start with the mesh ===
-    // First the data
-    // NB directory is never empty, due to the default of output.exporter_path
-    std::string directory = vm["output.exporter_path"].as<std::string>() + "/restart";
-
-    // create the output directory if it does not exist
-    fs::path output_path(directory);
-    if ( !fs::exists(output_path) )
-        fs::create_directories(output_path);
-
-    filename = (boost::format( "%1%/mesh_%2%.bin" )
-                % directory
-                % name_str ).str();
-
-    std::fstream meshbin(filename, std::ios::binary | std::ios::out | std::ios::trunc);
-    if ( ! meshbin.good() )
-        throw std::runtime_error("Cannot write to file: " + filename);
-    exporter.writeMesh(meshbin, M_mesh);
-    meshbin.close();
-
-    if (M_rank == 0) 
+    if (M_rank == 0)
     {
+        Exporter exporter("double");
+        std::string filename;
+
+        // === Start with the mesh ===
+        // First the data
+        // NB directory is never empty, due to the default of output.exporter_path
+        std::string directory = vm["output.exporter_path"].as<std::string>() + "/restart";
+
+        // create the output directory if it does not exist
+        fs::path output_path(directory);
+        if ( !fs::exists(output_path) )
+            fs::create_directories(output_path);
+
+        filename = (boost::format( "%1%/mesh_%2%.bin" )
+                    % directory
+                    % name_str ).str();
+
+        std::fstream meshbin(filename, std::ios::binary | std::ios::out | std::ios::trunc);
+        if ( ! meshbin.good() )
+            throw std::runtime_error("Cannot write to file: " + filename);
+        exporter.writeMesh(meshbin, M_mesh_root);
+        meshbin.close();
+
         // Then the record
         filename = (boost::format( "%1%/mesh_%2%.dat" )
                     % directory
@@ -14231,6 +14231,9 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
         bool const& export_fields, bool const& apply_displacement)
 {
 
+    std::vector<double> M_UM_root;
+    this->gatherNodalField(M_UM, M_UM_root);
+
     // fields defined on mesh elements
     M_prv_local_ndof = M_local_ndof;
     M_prv_num_nodes = M_num_nodes;
@@ -14241,6 +14244,7 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
     // get names of the variables in the output file,
     // and set pointers to the data (pointers to the corresponding vectors)
     // NB needs to be done on all processors
+    std::vector<double> M_surface_root;
     auto names_elements = M_export_names_elt;
     std::vector<ExternalData*> ext_data_elements;
     std::vector<double> elt_values_root;
@@ -14253,6 +14257,8 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
     std::vector<double> M_ssh_root;
     if(export_fields)
     {
+        M_surface_root = this->surface(M_mesh_root, M_UM_root);
+
         if(vm["output.save_forcing_fields"].as<bool>())
         {
             ext_data_elements = M_external_data_elements;
@@ -14276,32 +14282,36 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
         this->gatherNodalField(M_wind.getVector(),M_wind_root);
     }
     M_comm.barrier();
-
-    Exporter exporter(vm["output.exporter_precision"].as<std::string>());
-    std::string fileout;
-
-    if (export_mesh)
+    if (M_rank == 0)
     {
-        fileout = filenames[0]+".bin";
-        LOG(VERBOSE) <<"MESH BINARY: Exporter Filename= "<< fileout <<"\n";
 
-        // Make a copy of the mesh to avoid introduction of random modifications
-        // in the next timesteps introduced by two mesh moves (1 and -1) on M_mesh
-        mesh_type M_mesh_cpy = mesh_type();
-        M_mesh_cpy = M_mesh;
+        Exporter exporter(vm["output.exporter_precision"].as<std::string>());
+        std::string fileout;
 
-        // move the mesh for the export
-        if(apply_displacement) M_mesh_cpy.move(M_UM,1.);
-
-        std::fstream meshbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
-        if ( !meshbin.good() )
-            throw std::runtime_error("Cannot write to file: " + fileout);
-
-        exporter.writeMesh(meshbin, M_mesh_cpy);
-        meshbin.close();
-
-        if (M_rank == 0)
+        if (export_mesh)
         {
+            fileout = filenames[0]+".bin";
+            LOG(VERBOSE) <<"MESH BINARY: Exporter Filename= "<< fileout <<"\n";
+
+            if(apply_displacement)
+            {
+                // move the mesh for the export
+                M_mesh_root.move(M_UM_root,1.);
+            }
+
+            std::fstream meshbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
+            if ( !meshbin.good() )
+                throw std::runtime_error("Cannot write to file: " + fileout);
+
+            exporter.writeMesh(meshbin, M_mesh_root);
+            meshbin.close();
+
+            if(apply_displacement)
+            {
+                // move it back after the export
+                M_mesh_root.move(M_UM_root,-1.);
+            }
+
             fileout = filenames[0]+".dat";
 
             LOG(VERBOSE) <<"RECORD MESH: Exporter Filename= "<< fileout <<"\n";
@@ -14313,54 +14323,66 @@ FiniteElement::exportResults(std::vector<std::string> const& filenames, bool con
             exporter.writeRecord(outrecord,"mesh");
             outrecord.close();
         }
-    }
 
-    if (export_fields && M_rank == 0)
-    {
-        fileout = filenames[1]+".bin";
-        LOG(VERBOSE) <<"BINARY: Exporter Filename= "<< fileout <<"\n";
+        if (export_fields)
+        {
+            fileout = filenames[1]+".bin";
+            LOG(VERBOSE) <<"BINARY: Exporter Filename= "<< fileout <<"\n";
 
-        std::fstream outbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
-        if ( !outbin.good() )
-            throw std::runtime_error("Cannot write to file: " + fileout);
+            std::fstream outbin(fileout, std::ios::binary | std::ios::out | std::ios::trunc);
+            if ( !outbin.good() )
+                throw std::runtime_error("Cannot write to file: " + fileout);
 
-        std::vector<double> timevec = {M_current_time};
-        std::vector<int> regridvec = {M_nb_regrid};
+            std::vector<double> timevec = {M_current_time};
+            std::vector<int> regridvec = {M_nb_regrid};
 
-        exporter.writeField(outbin, timevec, "Time");
-        // exporter.writeField(outbin, regridvec, "M_nb_regrid");
-        // exporter.writeField(outbin, M_surface_root, "Element_area");
-        // exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags");
+            exporter.writeField(outbin, timevec, "Time");
+            // exporter.writeField(outbin, regridvec, "M_nb_regrid");
+            // exporter.writeField(outbin, M_surface_root, "Element_area");
+            // exporter.writeField(outbin, M_dirichlet_flags_root, "M_dirichlet_flags");
 
-        //manually export some vectors defined on the nodes
-        std::vector<std::string> names = vm["output.variables"].as<std::vector<std::string>>();
-        if ( std::find(names.begin(), names.end(), "M_VT") != names.end() )
-            exporter.writeField(outbin, M_VT_root, "M_VT");
+            //manually export some vectors defined on the nodes
+            std::vector<std::string> names = vm["output.variables"].as<std::vector<std::string>>();
+            if ( std::find(names.begin(), names.end(), "M_VT") != names.end() )
+                exporter.writeField(outbin, M_VT_root, "M_VT");
 #if defined (OASIS)
-        if (M_couple_waves && M_recv_wave_stress)
-            exporter.writeField(outbin, M_tau_wi_root, "M_tau_wi");
+            if (M_couple_waves && M_recv_wave_stress)
+                exporter.writeField(outbin, M_tau_wi_root, "M_tau_wi");
 #endif
-        if (vm["output.save_forcing_fields"].as<bool>())
-        {
-            exporter.writeField(outbin, M_wind_root, "M_wind");
-            exporter.writeField(outbin, M_ocean_root, "M_ocean");
-            exporter.writeField(outbin, M_ssh_root, "M_ssh");
-        }
-
-
-        // loop over the elemental variables that have been
-        // gathered to elt_values_root
-        int const nb_var_element = names_elements.size();
-        for(int j=0; j<nb_var_element; j++)
-        {
-            std::vector<double> tmp(M_mesh_root.numTriangles());
-            for (int i=0; i<M_mesh_root.numTriangles(); ++i)
+            if (vm["output.save_forcing_fields"].as<bool>())
             {
-                int ri = M_rmap_elements[i];
-                tmp[i] = elt_values_root[nb_var_element*ri+j];
+                exporter.writeField(outbin, M_wind_root, "M_wind");
+                exporter.writeField(outbin, M_ocean_root, "M_ocean");
+                exporter.writeField(outbin, M_ssh_root, "M_ssh");
             }
-            exporter.writeField(outbin, tmp, names_elements[j]);
 
+
+            // loop over the elemental variables that have been
+            // gathered to elt_values_root
+            int const nb_var_element = names_elements.size();
+            for(int j=0; j<nb_var_element; j++)
+            {
+                std::vector<double> tmp(M_mesh_root.numTriangles());
+                for (int i=0; i<M_mesh_root.numTriangles(); ++i)
+                {
+                    int ri = M_rmap_elements[i];
+                    tmp[i] = elt_values_root[nb_var_element*ri+j];
+                }
+                exporter.writeField(outbin, tmp, names_elements[j]);
+
+            }
+
+            outbin.close();
+
+            fileout = filenames[1]+".dat";
+            LOG(VERBOSE) <<"RECORD FIELD: Exporter Filename= "<< fileout <<"\n";
+
+            std::fstream outrecord(fileout, std::ios::out | std::ios::trunc);
+            if ( !outrecord.good() )
+                throw std::runtime_error("Cannot write to file: " + fileout);
+
+            exporter.writeRecord(outrecord);
+            outrecord.close();
         }
 
         outbin.close();

--- a/model/finiteelement.cpp
+++ b/model/finiteelement.cpp
@@ -9607,6 +9607,22 @@ FiniteElement::writeRestart(std::string const& name_str)
     std::vector<double> M_UM_root;
     std::vector<double> M_UT_root;
 
+#if 1
+    if (M_rank == 0)
+    {
+        // write node IDs manually to check against restarts
+        std::string filename = (boost::format( "%1%/restart/node_ids_%2%.txt" )
+                    % vm["output.exporter_path"].as<std::string>()
+                    % name_str ).str();
+        std::ofstream out_file(filename);
+        if (!out_file)
+            throw std::runtime_error("Cannot write to file: " + filename);
+        for (int val : M_mesh_root.id())
+            out_file << val << "\n";
+        out_file.close();
+    }
+#endif
+
     int tmp_nb_var=0;
 
     if (M_rank == 0)


### PR DESCRIPTION
Node IDs are not correctly output after PR #676. This PR simply reverts #676, but we should rework that PR to get parallel export working again.