### PR TITLE
Add compression to netCDF outputs

### DIFF
--- a/model/gridoutput.cpp
+++ b/model/gridoutput.cpp
@@ -933,6 +933,7 @@ GridOutput::initNetCDF(std::string file_prefix, fileLength file_length, double c
         data.putAtt("units",it->Units);
         data.putAtt("cell_methods", cell_methods_time + it->cell_methods);
         data.putAtt("_FillValue", netCDF::ncFloat, M_miss_val);
+        data.setCompression(shuffle, deflate, compression);
     }
     for (auto it=M_elemental_variables.begin(); it!=M_elemental_variables.end(); ++it)
     {
@@ -945,6 +946,7 @@ GridOutput::initNetCDF(std::string file_prefix, fileLength file_length, double c
         data.putAtt("units",it->Units);
         data.putAtt("cell_methods", cell_methods_time + it->cell_methods);
         data.putAtt("_FillValue", netCDF::ncFloat, M_miss_val);
+        data.setCompression(shuffle, deflate, compression);
     }
 
     // - set the global attributes

--- a/model/gridoutput.hpp
+++ b/model/gridoutput.hpp
@@ -1149,9 +1149,9 @@ private:
         std::vector<double>& ps_x, std::vector<double>& ps_y);
 
     // Compression options
-    bool shuffle = false;
-    bool deflate = true;
-    int compression = 4;
+    static constexpr bool shuffle = false;
+    static constexpr bool deflate = true;
+    static constexpr int compression = 4;
 
 };
 } // Nextsim

--- a/model/gridoutput.hpp
+++ b/model/gridoutput.hpp
@@ -1157,9 +1157,9 @@ private:
         std::vector<double>& ps_x, std::vector<double>& ps_y);
 
     // Compression options
-    bool shuffle = true;
+    bool shuffle = false;
     bool deflate = true;
-    int compression = 9;
+    int compression = 4;
 
 };
 } // Nextsim

--- a/model/gridoutput.hpp
+++ b/model/gridoutput.hpp
@@ -1094,14 +1094,6 @@ public:
 
     void info();
 
-    void setCompression(const bool enableShuffle, const bool enableDeflate, const int compressionLevel)
-    {
-        shuffle = enableShuffle;
-        deflate = enableDeflate;
-        compression = compressionLevel;
-    }
-
-
 private:
 
     LogLevel M_log_level;

--- a/model/gridoutput.hpp
+++ b/model/gridoutput.hpp
@@ -1094,6 +1094,14 @@ public:
 
     void info();
 
+    void setCompression(const bool enableShuffle, const bool enableDeflate, const int compressionLevel)
+    {
+        shuffle = enableShuffle;
+        deflate = enableDeflate;
+        compression = compressionLevel;
+    }
+
+
 private:
 
     LogLevel M_log_level;
@@ -1147,6 +1155,12 @@ private:
 
     void stereographicProjection(std::vector<double> const & x, std::vector<double> const & y, std::vector<double> const & z,
         std::vector<double>& ps_x, std::vector<double>& ps_y);
+
+    // Compression options
+    bool shuffle = true;
+    bool deflate = true;
+    int compression = 9;
+
 };
 } // Nextsim
 #endif // __GridOutput_H


### PR DESCRIPTION
Adds the ability to compress netCDF output. The performance impact is very little, but the files are much smaller (ymmv). The default is maximum compression and shuffling, but we can use GridData::setCompression to adjust.

We could (should) check if `shuffle` has much effect (the effect should be small) and what the optimal `compression` is (maybe 1 is enough).